### PR TITLE
Adventures: refactor create/edit and add success/error alerts

### DIFF
--- a/packages/common/src/components/Navbar.jsx
+++ b/packages/common/src/components/Navbar.jsx
@@ -32,7 +32,10 @@ export default function Navbar (props) {
               whitespace-nowrap uppercase`}
           >
             {logoUrl && <span><img src={logoUrl} className='inline-block max-h-8 mr-3' /></span>}
-            {title && <span className='inline-block align-middle'><Link to={homeUrl}>{title}</Link></span>}
+            {title &&
+              <span className='inline-block align-middle'>
+                <Link to={homeUrl} className={textColor}>{title}</Link>
+              </span>}
           </button>
           {(menuLinks?.length > 0) &&
             <button

--- a/packages/projects/src/components/ProjectForm.jsx
+++ b/packages/projects/src/components/ProjectForm.jsx
@@ -43,7 +43,7 @@ const INITIAL_STATE = {
   formStatus: FORM_STATUSES.clean,
   errorMessage: null,
   urlPlaceholder: '',
-  urlStatus: URL_STATUSES.clean,
+  urlStatus: URL_STATUSES.clean
 }
 
 const actions = {}

--- a/packages/projects/src/components/ProjectForm.jsx
+++ b/packages/projects/src/components/ProjectForm.jsx
@@ -16,7 +16,8 @@ import remarkBreaks from 'remark-breaks'
 import emoji from 'remark-emoji'
 
 import { MDXProvider, useMDXComponents } from '@mdx-js/react'
-import { CodePen, Gist, Figma } from 'mdx-embed'
+
+import { components } from 'constants.js'
 
 const INITIAL_STATE = { url: '', title: '', markdown: '' }
 
@@ -36,20 +37,6 @@ const reducer = (state, action) => {
     throw new Error('UnknownActionError', { cause: `Unhandled action: ${action.type}` })
   }
 }
-
-/* eslint-disable */
-const components = {
-  table: (props) => <table {...props} className="border-collapse table-auto w-full text-sm" />,
-  th: (props) => <th {...props} className="border-b dark:border-slate-600 font-medium p-4 pl-8 pt-0 pb-3 text-slate-400 dark:text-slate-200 text-left" />,
-  td: (props) => <td {...props} className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400" />,
-  h1: (props) => <h1 {...props} className="text-3xl" />,
-  h2: (props) => <h2 {...props} className="text-xl" />,
-  h3: (props) => <h3 {...props} className="text-lg" />,
-  ul: (props) => <ul {...props} className="list-disc" />,
-  ol: (props) => <ul {...props} className="list-decimal" />,
-  CodePen, Gist, Figma
-}
-/* eslint-enable */
 
 const formClass = 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50'
 

--- a/packages/projects/src/components/ProjectForm.jsx
+++ b/packages/projects/src/components/ProjectForm.jsx
@@ -75,13 +75,8 @@ const save = async (state, dispatch, mode, e) => {
   dispatch({ type: 'formStatus', payload: 'submitting' })
   dispatch({ type: 'errorMessage', payload: null })
 
-  const { projects, title, url, markdown, urlPlaceholder } = state
+  const { projects, title, url, markdown } = state
   const data = { title, url, markdown }
-
-  if (!url || url.length === 0) {
-    data.url = urlPlaceholder
-    dispatch({ type: 'url', payload: urlPlaceholder })
-  }
 
   try {
     let saved
@@ -106,6 +101,15 @@ const toKebabCase = str =>
       .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
       .join('-')
       .toLowerCase()
+
+const setUrl = (state, dispatch) => {
+  const title = value(state, 'title')
+  const url = value(state, 'url')
+
+  if (!url || url.length === 0) {
+    dispatch({ type: 'url', payload: toKebabCase(title) })
+  }
+}
 
 const setUrlPlaceholder = (title, dispatch) => {
   const newUrlPlaceholder = toKebabCase(title)
@@ -222,6 +226,7 @@ const ProjectForm = ({ mode, projectHandle }) => {
             <input
               type='text' className={formClass}
               value={value(state, 'title')} onChange={change.bind(null, dispatch, 'title')}
+              onBlur={setUrl.bind(null, state, dispatch)}
             />
           </label>
           <label className='block'>

--- a/packages/projects/src/components/ProjectForm.jsx
+++ b/packages/projects/src/components/ProjectForm.jsx
@@ -278,6 +278,10 @@ const ProjectForm = ({ mode, projectHandle }) => {
           </label>
           <label className='block'>
             <span className='text-gray-700'>Markdown</span>
+            <br />
+            <span className='text-gray-500 text-sm'>
+              Here's a <a href='https://www.markdownguide.org/cheat-sheet/' target='_blank' rel='noreferrer'>cheat sheet</a> for Markdown syntax.
+            </span>
             <textarea
               rows='10' className={formClass} value={markdown}
               onChange={(e) => setMarkdown(e.target.value)}

--- a/packages/projects/src/components/ProjectForm.jsx
+++ b/packages/projects/src/components/ProjectForm.jsx
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) Kernel
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useEffect, useReducer, useState, Fragment } from 'react'
+import { useServices } from '@kernel/common'
+
+import * as runtime from 'react/jsx-runtime.js'
+import { evaluate } from '@mdx-js/mdx'
+import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
+import emoji from 'remark-emoji'
+
+import { MDXProvider, useMDXComponents } from '@mdx-js/react'
+import { CodePen, Gist, Figma } from 'mdx-embed'
+
+const INITIAL_STATE = { url: '', title: '', markdown: '' }
+
+const actions = {
+  url: (state, url) => Object.assign({}, state, { url }),
+  title: (state, title) => Object.assign({}, state, { title }),
+  markdown: (state, markdown) => Object.assign({}, state, { markdown }),
+  projects: (state, projects) => Object.assign({}, state, { projects })
+}
+
+const reducer = (state, action) => {
+  try {
+    // console.log(action.type, action.payload, state)
+    return actions[action.type](state, action.payload)
+  } catch (error) {
+    console.log(error)
+    throw new Error('UnknownActionError', { cause: `Unhandled action: ${action.type}` })
+  }
+}
+
+/* eslint-disable */
+const components = {
+  table: (props) => <table {...props} className="border-collapse table-auto w-full text-sm" />,
+  th: (props) => <th {...props} className="border-b dark:border-slate-600 font-medium p-4 pl-8 pt-0 pb-3 text-slate-400 dark:text-slate-200 text-left" />,
+  td: (props) => <td {...props} className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400" />,
+  h1: (props) => <h1 {...props} className="text-3xl" />,
+  h2: (props) => <h2 {...props} className="text-xl" />,
+  h3: (props) => <h3 {...props} className="text-lg" />,
+  ul: (props) => <ul {...props} className="list-disc" />,
+  ol: (props) => <ul {...props} className="list-decimal" />,
+  CodePen, Gist, Figma
+}
+/* eslint-enable */
+
+const formClass = 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50'
+
+const change = (dispatch, type, e) => {
+  try {
+    e.preventDefault()
+    const payload = e.target.value
+    dispatch({ type, payload })
+  } catch (error) {
+    console.log(error)
+  }
+}
+
+const value = (state, type) => {
+  console.log(type, state)
+
+  return state[type]
+}
+
+const create = async (state, dispatch, e) => {
+  e.preventDefault()
+  const { projects, title, url, markdown } = state
+  const data = { title, url, markdown }
+  const created = await projects.create(data, { id: url })
+  // dispatch({ type: 'created', payload: updated })
+  console.log(created)
+}
+
+const update = async (state, dispatch, e) => {
+  e.preventDefault()
+  const { projects, title, url, markdown } = state
+  const data = { title, url, markdown }
+  const updated = await projects.update(url, data)
+  // dispatch({ type: 'created', payload: updated })
+  console.log(updated)
+}
+
+const ProjectForm = ({ mode, projectHandle }) => {
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  const { services } = useServices()
+
+  useEffect(() => {
+    (async () => {
+      const { entityFactory } = await services()
+      const resource = 'project'
+      const projects = await entityFactory({ resource })
+      dispatch({ type: 'projects', payload: projects })
+
+      if (mode === 'edit') {
+        const projectEntity = await projects.get(projectHandle)
+        setMarkdown(projectEntity.data.markdown)
+        dispatch({ type: 'url', payload: projectEntity.data.url })
+        dispatch({ type: 'title', payload: projectEntity.data.title })
+        dispatch({ type: 'markdown', payload: projectEntity.data.markdown })
+      }
+    })()
+  }, [services, projectHandle, mode])
+
+  const [markdown, setMarkdown] = useState('')
+  const [markdownError, setMarkdownError] = useState(null)
+  const [mdxModule, setMdxModule] = useState()
+
+  const Content = mdxModule ? mdxModule.default : Fragment
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setMarkdownError(null)
+        const code = await evaluate(markdown, {
+          jsx: runtime.jsx,
+          jsxs: runtime.jsxs,
+          Fragment,
+          useMDXComponents,
+          outputFormat: 'function-body',
+          remarkPlugins: [remarkGfm, remarkBreaks, emoji]
+        })
+        setMdxModule(code)
+        dispatch({ type: 'markdown', payload: markdown })
+      } catch (error) {
+        console.log(error.message)
+        setMarkdownError(error)
+      }
+    })()
+  }, [markdown])
+
+  const apiMethod = { create, edit: update }[mode]
+
+  return (
+    <div className='grid grid-cols-2 mb-24'>
+      <div className='px-8'>
+        <form className='grid grid-cols-1 gap-6'>
+          <label className='block'>
+            <span className='text-gray-700'>Title</span>
+            <input
+              type='text' className={formClass}
+              value={value(state, 'title')} onChange={change.bind(null, dispatch, 'title')}
+            />
+          </label>
+          <label className='block'>
+            <span className='text-gray-700'>URL</span>
+            <input
+              type='text' className={formClass}
+              value={value(state, 'url')} onChange={change.bind(null, dispatch, 'url')}
+            />
+          </label>
+          <label className='block'>
+            <span className='text-gray-700'>Template</span>
+            <select className={formClass}>
+              <option>Adventure</option>
+            </select>
+          </label>
+          <label className='block'>
+            <span className='text-gray-700'>Markdown</span>
+            <textarea
+              rows='10' className={formClass} value={markdown}
+              onChange={(e) => setMarkdown(e.target.value)}
+            />
+          </label>
+          <label className='block'>
+            <button
+              onClick={apiMethod.bind(null, state, dispatch)}
+              className='w-full py-2 px-3 bg-indigo-500 text-white text-sm font-semibold rounded-md shadow focus:outline-none'
+            >
+              {mode === 'create' ? 'Create' : 'Save'}
+            </button>
+          </label>
+          {markdownError &&
+            <label className='block'>
+              <span className='text-gray-700'>Error</span>
+              <div className={formClass}>
+                {markdownError.message}
+              </div>
+            </label>}
+        </form>
+      </div>
+      <div className='px-8 rounded-md border-gray-800 shadow-lg'>
+        <MDXProvider components={components}>
+          <Content />
+        </MDXProvider>
+      </div>
+    </div>
+  )
+}
+
+export default ProjectForm

--- a/packages/projects/src/components/ProjectForm.jsx
+++ b/packages/projects/src/components/ProjectForm.jsx
@@ -69,7 +69,7 @@ const save = async (state, dispatch, mode, e) => {
 
   const { projects, title, url, markdown } = state
   const data = { title, url, markdown }
-  
+
   try {
     let saved
     if (mode === 'create') {
@@ -201,8 +201,10 @@ const ProjectForm = ({ mode, projectHandle }) => {
       </div>
 
       <div className='my-4 px-8'>
-        <ProjectFormAlert formStatus={state.formStatus} errorMessage={state.errorMessage}
-          projectHandle={mode === 'create' ? value(state, 'url') : projectHandle} />
+        <ProjectFormAlert
+          formStatus={state.formStatus} errorMessage={state.errorMessage}
+          projectHandle={mode === 'create' ? value(state, 'url') : projectHandle}
+        />
         {markdownError &&
           <label className='my-8 block'>
             <span className='text-gray-700'>Error</span>

--- a/packages/projects/src/components/ProjectForm.jsx
+++ b/packages/projects/src/components/ProjectForm.jsx
@@ -100,7 +100,7 @@ const save = async (state, dispatch, mode, e) => {
     if (mode === 'create') {
       saved = await projects.create(data, { id: data.url })
     } else if (mode === 'edit') {
-      saved = await projects.update(url, data)
+      saved = await projects.patch(url, { title, markdown })
     }
     dispatch({ type: 'formStatus', payload: FORM_STATUSES.success })
     console.log(saved)
@@ -156,10 +156,8 @@ const validateUrl = async (url, state, dispatch) => {
     return
   }
 
-  const allProjects = await state.projects.getAll()
-  const allProjectIds = Object.values(allProjects).map(project => project.id)
-
-  const urlStatus = allProjectIds.includes(url) ? URL_STATUSES.taken : URL_STATUSES.valid
+  const taken = await state.projects.exists(url)
+  const urlStatus = taken ? URL_STATUSES.taken : URL_STATUSES.valid
   dispatch({ type: 'urlStatus', payload: urlStatus })
 }
 

--- a/packages/projects/src/constants.js
+++ b/packages/projects/src/constants.js
@@ -1,0 +1,17 @@
+import { CodePen, Gist, Figma } from 'mdx-embed'
+
+/* eslint-disable */
+const components = {
+  table: (props) => <table {...props} className="border-collapse table-auto w-full text-sm" />,
+  th: (props) => <th {...props} className="border-b dark:border-slate-600 font-medium p-4 pl-8 pt-0 pb-3 text-slate-400 dark:text-slate-200 text-left" />,
+  td: (props) => <td {...props} className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400" />,
+  h1: (props) => <h1 {...props} className="text-3xl" />,
+  h2: (props) => <h2 {...props} className="text-xl" />,
+  h3: (props) => <h3 {...props} className="text-lg" />,
+  ul: (props) => <ul {...props} className="list-disc" />,
+  ol: (props) => <ul {...props} className="list-decimal" />,
+  CodePen, Gist, Figma
+}
+/* eslint-enable */
+
+export { components }

--- a/packages/projects/src/index.scss
+++ b/packages/projects/src/index.scss
@@ -1,3 +1,9 @@
 @tailwind base;
+
+@layer base {
+  a {
+    @apply text-kernel-eggplant-light
+  }
+}
 @tailwind components;
 @tailwind utilities;

--- a/packages/projects/src/views/Create.jsx
+++ b/packages/projects/src/views/Create.jsx
@@ -6,88 +6,19 @@
  *
  */
 
-import { useEffect, useReducer, useState, Fragment } from 'react'
+import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useServices } from '@kernel/common'
-
-import * as runtime from 'react/jsx-runtime.js'
-import { evaluate } from '@mdx-js/mdx'
-import remarkGfm from 'remark-gfm'
-import remarkBreaks from 'remark-breaks'
-import emoji from 'remark-emoji'
-
-import { MDXProvider, useMDXComponents } from '@mdx-js/react'
-import { CodePen, Gist, Figma } from 'mdx-embed'
 
 import AppConfig from 'App.config'
 
 import Page from 'components/Page'
-
-const INITIAL_STATE = { url: '', title: '', markdown: '' }
-
-const actions = {
-  url: (state, url) => Object.assign({}, state, { url }),
-  title: (state, title) => Object.assign({}, state, { title }),
-  markdown: (state, markdown) => Object.assign({}, state, { markdown }),
-  projects: (state, projects) => Object.assign({}, state, { projects })
-}
-
-const reducer = (state, action) => {
-  try {
-    // console.log(action.type, action.payload, state)
-    return actions[action.type](state, action.payload)
-  } catch (error) {
-    console.log(error)
-    throw new Error('UnknownActionError', { cause: `Unhandled action: ${action.type}` })
-  }
-}
-
-/* eslint-disable */
-const components = {
-  table: (props) => <table {...props} className="border-collapse table-auto w-full text-sm" />,
-  th: (props) => <th {...props} className="border-b dark:border-slate-600 font-medium p-4 pl-8 pt-0 pb-3 text-slate-400 dark:text-slate-200 text-left" />,
-  td: (props) => <td {...props} className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400" />,
-  h1: (props) => <h1 {...props} className="text-3xl" />,
-  h2: (props) => <h2 {...props} className="text-xl" />,
-  h3: (props) => <h3 {...props} className="text-lg" />,
-  ul: (props) => <ul {...props} className="list-disc" />,
-  ol: (props) => <ul {...props} className="list-decimal" />,
-  CodePen, Gist, Figma
-}
-/* eslint-enable */
-
-const formClass = 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50'
-
-const change = (dispatch, type, e) => {
-  try {
-    e.preventDefault()
-    const payload = e.target.value
-    dispatch({ type, payload })
-  } catch (error) {
-    console.log(error)
-  }
-}
-
-const value = (state, type) => {
-  console.log(type, state)
-
-  return state[type]
-}
-
-const create = async (state, dispatch, e) => {
-  e.preventDefault()
-  const { projects, title, url, markdown } = state
-  const data = { title, url, markdown }
-  const created = await projects.create(data, { id: url })
-  // dispatch({ type: 'created', payload: updated })
-  console.log(created)
-}
+import ProjectForm from 'components/ProjectForm'
 
 const Create = () => {
-  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
   const navigate = useNavigate()
 
-  const { services, currentUser } = useServices()
+  const { currentUser } = useServices()
   const user = currentUser()
 
   useEffect(() => {
@@ -96,97 +27,9 @@ const Create = () => {
     }
   }, [navigate, user])
 
-  useEffect(() => {
-    (async () => {
-      const { entityFactory } = await services()
-      const resource = 'project'
-      const projects = await entityFactory({ resource })
-      dispatch({ type: 'projects', payload: projects })
-    })()
-  }, [services])
-
-  const [markdown, setMarkdown] = useState()
-  const [markdownError, setMarkdownError] = useState(null)
-  const [mdxModule, setMdxModule] = useState()
-
-  const Content = mdxModule ? mdxModule.default : Fragment
-
-  useEffect(() => {
-    (async () => {
-      try {
-        setMarkdownError(null)
-        const code = await evaluate(markdown, {
-          jsx: runtime.jsx,
-          jsxs: runtime.jsxs,
-          Fragment,
-          useMDXComponents,
-          outputFormat: 'function-body',
-          remarkPlugins: [remarkGfm, remarkBreaks, emoji]
-        })
-        setMdxModule(code)
-        dispatch({ type: 'markdown', payload: markdown })
-      } catch (error) {
-        console.log(error.message)
-        setMarkdownError(error)
-      }
-    })()
-  }, [markdown])
-
   return (
     <Page>
-      <div className='grid grid-cols-2 mb-24'>
-        <div className='px-8'>
-          <form className='grid grid-cols-1 gap-6'>
-            <label className='block'>
-              <span className='text-gray-700'>Title</span>
-              <input
-                type='text' className={formClass}
-                value={value(state, 'title')} onChange={change.bind(null, dispatch, 'title')}
-              />
-            </label>
-            <label className='block'>
-              <span className='text-gray-700'>URL</span>
-              <input
-                type='text' className={formClass}
-                value={value(state, 'url')} onChange={change.bind(null, dispatch, 'url')}
-              />
-            </label>
-            <label className='block'>
-              <span className='text-gray-700'>Template</span>
-              <select className={formClass}>
-                <option>Adventure</option>
-              </select>
-            </label>
-            <label className='block'>
-              <span className='text-gray-700'>Markdown</span>
-              <textarea
-                rows='10' className={formClass}
-                onChange={(e) => setMarkdown(e.target.value)}
-              />
-            </label>
-            <label className='block'>
-              <button
-                onClick={create.bind(null, state, dispatch)}
-                className='w-full py-2 px-3 bg-indigo-500 text-white text-sm font-semibold rounded-md shadow focus:outline-none'
-              >
-                Create
-              </button>
-            </label>
-            {markdownError &&
-              <label className='block'>
-                <span className='text-gray-700'>Error</span>
-                <div className={formClass}>
-                  {markdownError.message}
-                </div>
-              </label>}
-          </form>
-        </div>
-        <div className='px-8 rounded-md border-gray-800 shadow-lg'>
-          <MDXProvider components={components}>
-            <Content />
-          </MDXProvider>
-        </div>
-      </div>
+      <ProjectForm mode='create' />
     </Page>
   )
 }

--- a/packages/projects/src/views/Edit.jsx
+++ b/packages/projects/src/views/Edit.jsx
@@ -6,89 +6,20 @@
  *
  */
 
-import { useEffect, useReducer, useState, Fragment } from 'react'
+import { useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useServices } from '@kernel/common'
-
-import * as runtime from 'react/jsx-runtime.js'
-import { evaluate } from '@mdx-js/mdx'
-import remarkGfm from 'remark-gfm'
-import remarkBreaks from 'remark-breaks'
-import emoji from 'remark-emoji'
-
-import { MDXProvider, useMDXComponents } from '@mdx-js/react'
-import { CodePen, Gist, Figma } from 'mdx-embed'
 
 import AppConfig from 'App.config'
 
 import Page from 'components/Page'
-
-const INITIAL_STATE = { url: '', title: '', markdown: '' }
-
-const actions = {
-  url: (state, url) => Object.assign({}, state, { url }),
-  title: (state, title) => Object.assign({}, state, { title }),
-  markdown: (state, markdown) => Object.assign({}, state, { markdown }),
-  projects: (state, projects) => Object.assign({}, state, { projects })
-}
-
-const reducer = (state, action) => {
-  try {
-    console.log(action.type, action.payload, state)
-    return actions[action.type](state, action.payload)
-  } catch (error) {
-    console.log(error)
-    throw new Error('UnknownActionError', { cause: `Unhandled action: ${action.type}` })
-  }
-}
-
-/* eslint-disable */
-const components = {
-  table: (props) => <table {...props} className="border-collapse table-auto w-full text-sm" />,
-  th: (props) => <th {...props} className="border-b dark:border-slate-600 font-medium p-4 pl-8 pt-0 pb-3 text-slate-400 dark:text-slate-200 text-left" />,
-  td: (props) => <td {...props} className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400" />,
-  h1: (props) => <h1 {...props} className="text-3xl" />,
-  h2: (props) => <h2 {...props} className="text-xl" />,
-  h3: (props) => <h3 {...props} className="text-lg" />,
-  ul: (props) => <ul {...props} className="list-disc" />,
-  ol: (props) => <ul {...props} className="list-decimal" />,
-  CodePen, Gist, Figma
-}
-/* eslint-enable */
-
-const formClass = 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50'
-
-const change = (dispatch, type, e) => {
-  try {
-    e.preventDefault()
-    const payload = e.target.value
-    dispatch({ type, payload })
-  } catch (error) {
-    console.log(error)
-  }
-}
-
-const value = (state, type) => {
-  console.log(type, state)
-
-  return state[type]
-}
-
-const update = async (state, dispatch, e) => {
-  e.preventDefault()
-  const { projects, title, url, markdown } = state
-  const data = { title, url, markdown }
-  const updated = await projects.update(url, data)
-  // dispatch({ type: 'created', payload: updated })
-  console.log(updated)
-}
+import ProjectForm from 'components/ProjectForm'
 
 const Edit = () => {
-  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
   const navigate = useNavigate()
   const { project } = useParams()
 
-  const { services, currentUser } = useServices()
+  const { currentUser } = useServices()
   const user = currentUser()
 
   useEffect(() => {
@@ -97,102 +28,9 @@ const Edit = () => {
     }
   }, [navigate, user])
 
-  useEffect(() => {
-    (async () => {
-      const { entityFactory } = await services()
-      const resource = 'project'
-      const projects = await entityFactory({ resource })
-      dispatch({ type: 'projects', payload: projects })
-      const projectEntity = await projects.get(project)
-      setMarkdown(projectEntity.data.markdown)
-      dispatch({ type: 'url', payload: projectEntity.data.url })
-      dispatch({ type: 'title', payload: projectEntity.data.title })
-      dispatch({ type: 'markdown', payload: projectEntity.data.markdown })
-    })()
-  }, [services, project])
-
-  const [markdown, setMarkdown] = useState('')
-  const [markdownError, setMarkdownError] = useState(null)
-  const [mdxModule, setMdxModule] = useState()
-
-  const Content = mdxModule ? mdxModule.default : Fragment
-
-  useEffect(() => {
-    (async () => {
-      try {
-        setMarkdownError(null)
-        const code = await evaluate(markdown, {
-          jsx: runtime.jsx,
-          jsxs: runtime.jsxs,
-          Fragment,
-          useMDXComponents,
-          outputFormat: 'function-body',
-          remarkPlugins: [remarkGfm, remarkBreaks, emoji]
-        })
-        setMdxModule(code)
-        dispatch({ type: 'markdown', payload: markdown })
-      } catch (error) {
-        console.log(error.message)
-        setMarkdownError(error)
-      }
-    })()
-  }, [markdown])
-
   return (
     <Page>
-      <div className='grid grid-cols-2 mb-24'>
-        <div className='px-8'>
-          <form className='grid grid-cols-1 gap-6'>
-            <label className='block'>
-              <span className='text-gray-700'>Title</span>
-              <input
-                type='text' className={formClass}
-                value={value(state, 'title')} onChange={change.bind(null, dispatch, 'title')}
-              />
-            </label>
-            <label className='block'>
-              <span className='text-gray-700'>URL</span>
-              <input
-                type='text' className={formClass} disabled='true'
-                value={value(state, 'url')} onChange={change.bind(null, dispatch, 'url')}
-              />
-            </label>
-            <label className='block'>
-              <span className='text-gray-700'>Template</span>
-              <select className={formClass}>
-                <option>Adventure</option>
-              </select>
-            </label>
-            <label className='block'>
-              <span className='text-gray-700'>Markdown</span>
-              <textarea
-                rows='10' className={formClass} value={markdown}
-                onChange={(e) => setMarkdown(e.target.value)}
-              />
-            </label>
-            <label className='block'>
-              <button
-                onClick={update.bind(null, state, dispatch)}
-                className='w-full py-2 px-3 bg-indigo-500 text-white text-sm font-semibold rounded-md shadow focus:outline-none'
-              >
-                Update
-              </button>
-            </label>
-            {markdownError &&
-              <label className='block'>
-                <span className='text-gray-700'>Error</span>
-                <div className={formClass}>
-                  {markdownError.message}
-                </div>
-              </label>}
-          </form>
-        </div>
-        <div className='md:basis-1/2 grow px-8 rounded-md border-gray-800 shadow-lg'>
-          <MDXProvider components={components}>
-            <Content />
-          </MDXProvider>
-        </div>
-      </div>
+      <ProjectForm mode='edit' projectHandle={project} />
     </Page>
   )
 }

--- a/packages/projects/src/views/View.jsx
+++ b/packages/projects/src/views/View.jsx
@@ -17,25 +17,11 @@ import remarkBreaks from 'remark-breaks'
 import emoji from 'remark-emoji'
 
 import { MDXProvider, useMDXComponents } from '@mdx-js/react'
-import { CodePen, Gist, Figma } from 'mdx-embed'
 
 import AppConfig from 'App.config'
+import { components } from 'constants.js'
 
 import Page from 'components/Page'
-
-/* eslint-disable */
-const components = {
-  table: (props) => <table {...props} className="border-collapse table-auto w-full text-sm" />,
-  th: (props) => <th {...props} className="border-b dark:border-slate-600 font-medium p-4 pl-8 pt-0 pb-3 text-slate-400 dark:text-slate-200 text-left" />,
-  td: (props) => <td {...props} className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400" />,
-  h1: (props) => <h1 {...props} className="text-3xl" />,
-  h2: (props) => <h2 {...props} className="text-xl" />,
-  h3: (props) => <h3 {...props} className="text-lg" />,
-  ul: (props) => <ul {...props} className="list-disc" />,
-  ol: (props) => <ul {...props} className="list-decimal" />,
-  CodePen, Gist, Figma
-}
-/* eslint-enable */
 
 const View = () => {
   const navigate = useNavigate()


### PR DESCRIPTION
+ Extracts Create/Edit into a shared ProjectForm component
+ Extracts `components` into a constants file
+ Adds success/error alerts on create and edit
+ Improves UX of URL field (now named "Handle"): helper text, auto-generated placeholder text, frontend validations for uniqueness and allowed characters
+ Disable `handle` field when editing a project.

It's too tricky to allow the project `handle` of an existing project to be edited because that's the project's canonical id and therefore:
+ Can't validate uniqueness: the logic should be that it's okay if the handle already exists, ONLY if it's "your" project. But we have no concept yet of "your" project vs. projects created by other people, so we can't distinguish this.
+ Currently the backend doesn't validate for uniqueness on edit, so if you change the handle to a different existing project's handle, it just overwrites all the data of the other project. I think we should prevent this until we have more permissions set up.

Addresses #5 and #6 

Success/error alerts on save:
<img width="639" alt="Screen Shot 2022-05-23 at 11 52 24 AM" src="https://user-images.githubusercontent.com/4686089/169860417-b7e3545a-9d80-4c8e-9971-dcdb9a89f242.png">

Placeholder handle is generated as you type the title. If you leave the handle field blank, the `url` field will be populated from this placeholder.
![Screen Shot 2022-05-23 at 7 29 09 PM](https://user-images.githubusercontent.com/4686089/169920801-d4fc5540-3b7a-4807-b9e6-7e4dbc1a860e.png)

If you do type a handle, it will be validated for uniqueness on focus-out.
![Screen Shot 2022-05-23 at 7 20 27 PM](https://user-images.githubusercontent.com/4686089/169920830-b7367040-f52d-44c0-9a4e-484e66e8353b.png)

