### PR TITLE
Chat submit metaenter

### DIFF
--- a/packages/chat/src/views/View.js
+++ b/packages/chat/src/views/View.js
@@ -122,7 +122,7 @@ const switchChannel = (state, step) => {
   const { active, channels } = state
   const cnt = Object.keys(channels).length
   const index = Object.values(channels)
-      .reduce((acc, {data: { name }}, i) => name === active ? i : acc, -1) + step
+    .reduce((acc, { data: { name } }, i) => name === active ? i : acc, -1) + step
 
   // https://stackoverflow.com/a/45397704
   const newIndex = (index % cnt + cnt) % cnt
@@ -130,7 +130,7 @@ const switchChannel = (state, step) => {
   return channel
 }
 
-const STEPS = {'ArrowDown': -1, 'ArrowUp': 1}
+const STEPS = { ArrowDown: -1, ArrowUp: 1 }
 
 const handleKeys = async (state, dispatch, e) => {
   // bail early if meta/ctrl key not pressed. Other keys can be added in the future to trigger the hotkeys
@@ -145,7 +145,6 @@ const handleKeys = async (state, dispatch, e) => {
     const step = STEPS[e.key]
     const channel = switchChannel(state, step)
     await changeChannel(state, dispatch, channel)
-    return
   }
 }
 

--- a/packages/chat/src/views/View.js
+++ b/packages/chat/src/views/View.js
@@ -118,7 +118,7 @@ const Textarea = ({ state, dispatch }) => {
 }
 
 const handleMetaEnter = e => {
-  if(e.key === 'Enter' && e.metaKey){
+  if(e.key === 'Enter' && (e.metaKey || e.ctrlKey)){
     e.preventDefault()
     e.target.form.requestSubmit()
   }

--- a/packages/chat/src/views/View.js
+++ b/packages/chat/src/views/View.js
@@ -112,8 +112,16 @@ const Textarea = ({ state, dispatch }) => {
   return (
     <textarea
       className='w-full' rows='5' value={value(state, 'content')} onChange={change.bind(null, dispatch, 'content')}
+      onKeyDown={e=>{handleMetaEnter(e)}}
     />
   )
+}
+
+const handleMetaEnter = e => {
+  if(e.key === 'Enter' && e.metaKey){
+    e.preventDefault()
+    e.target.form.requestSubmit()
+  }
 }
 
 const Page = () => {
@@ -193,7 +201,7 @@ const Page = () => {
         </div>
         <div className='md:basis-2/3 grow px-8 rounded-md border-gray-800 shadow-lg min-h-screen'>
           <p className='uppercase'>Messages</p>
-          <form onSubmit={sendMessage.bind(null, state, dispatch)}>
+          <form onSubmit={sendMessage.bind(null, state, dispatch)} >
             <Textarea state={state} dispatch={dispatch} />
             <input
               value='Send' type='submit' disabled={state.loading}

--- a/packages/chat/src/views/View.js
+++ b/packages/chat/src/views/View.js
@@ -106,21 +106,38 @@ const Textarea = ({ state, dispatch }) => {
       <textarea
         className='w-full' rows='5' readOnly={!!state.loading}
         value={value(state, 'content')} onChange={change.bind(null, dispatch, 'content')}
+        onKeyDown={handleKeys.bind(null, state, dispatch)}
       />
     )
   }
   return (
     <textarea
       className='w-full' rows='5' value={value(state, 'content')} onChange={change.bind(null, dispatch, 'content')}
-      onKeyDown={e=>{handleMetaEnter(e)}}
+      onKeyDown={handleKeys.bind(null, state, dispatch)}
     />
   )
 }
 
-const handleMetaEnter = e => {
-  if(e.key === 'Enter' && (e.metaKey || e.ctrlKey)){
+const handleKeys = async (state, dispatch, e) => {
+  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
     e.preventDefault()
-    e.target.form.requestSubmit()
+    await sendMessage(state, dispatch, e)
+  } else if (e.key === 'ArrowUp' && (e.metaKey || e.ctrlKey) && state && state.channels) {
+    e.preventDefault()
+    const _channels = Object.values(state.channels)
+    const _current = _channels.find(c => {
+      return state.active === c.data.name
+    })
+    const _index = (_channels.indexOf(_current) - 1 < 0 ? _channels.length - 1 : _channels.indexOf(_current) - 1)
+    await changeChannel(state, dispatch, _channels[_index])
+  } else if (e.key === 'ArrowDown' && (e.metaKey || e.ctrlKey) && state && state.channels) {
+    e.preventDefault()
+    const _channels = Object.values(state.channels)
+    const _current = _channels.find(c => {
+      return state.active === c.data.name
+    })
+    const _index = (_channels.indexOf(_current) + 1) % _channels.length
+    await changeChannel(state, dispatch, _channels[_index])
   }
 }
 
@@ -201,7 +218,7 @@ const Page = () => {
         </div>
         <div className='md:basis-2/3 grow px-8 rounded-md border-gray-800 shadow-lg min-h-screen'>
           <p className='uppercase'>Messages</p>
-          <form onSubmit={sendMessage.bind(null, state, dispatch)} >
+          <form onSubmit={sendMessage.bind(null, state, dispatch)}>
             <Textarea state={state} dispatch={dispatch} />
             <input
               value='Send' type='submit' disabled={state.loading}


### PR DESCRIPTION
Small contribution to chat UX: submit on special enter, ie command+enter on mac or control+enter on pc
No more need to use your mouse to click the button or tab to change focus! just press cmd+enter or control+enter to submit the chat
I'm a newbie, so forgive any mistakes or non-conventions