### PR TITLE
adding solid foothold to build upon

### DIFF
--- a/packages/common/src/components/Footer.jsx
+++ b/packages/common/src/components/Footer.jsx
@@ -7,23 +7,51 @@
  */
 
 import React from 'react'
+import { FooterLink } from '@kernel/common'
 
+const env = process.env.REACT_APP_DEPLOY_TARGET || 'PROD'
+const prefix = env === 'STAGING' ? 'staging.' : ''
 const defaults = {
   backgroundColor: 'bg-gray-900',
-  textColor: 'text-white'
+  textColor: 'text-white',
+  footerLinks: [
+    { href: 'https://' + prefix + 'explore.kernel.community', title: 'explorer' },
+    { href: 'https://' + prefix + 'unprofile.kernel.community', title: 'unprofile' },
+    { href: 'https://' + prefix + 'adventures.kernel.community', title: 'adventures' },
+    { href: 'https://' + prefix + 'wallet.kernel.community', title: 'portal' },
+  ]
 }
 
-export default function Footer (props) {
+export default function Footer(props) {
   const { children } = props
+  /* TODO: address when Footer has a single child which is not a link */
+  const links = children ?
+    children.length > 1 ?
+      children
+        .filter(link => link.props !== undefined)
+        .map((link) => ({ href: link.props.href, title: link.props.children }))
+      : [{ href: children.props.href, title: children.props.children }]
+    : defaults.footerLinks
   const backgroundColor = props.backgroundColor || defaults.backgroundColor
   const textColor = props.textColor || defaults.textColor
 
   return (
     <>
       <footer className={backgroundColor}>
-        <div className={`px-4 py-6 text-sm ${textColor} font-semibold`}>
+        <div className={`px-4 py-6 text-sm ${textColor}`}>
           <div className='text-center'>
-            {children}
+            <ul className='flex justify-center flex-col lg:flex-row list-none ml-3 mt-3 lg:mt-0 font-semibold'>
+              {links.map((link, idx) => {
+                return (
+                  <li key={idx} className='flex items-center'>
+                    <FooterLink link={link} textColor={textColor} />
+                  </li>
+                )
+              })}
+            </ul>
+            <div className='mt-5'>
+              built at <a href='https://kernel.community/' className='text-kernel-green-light'>KERNEL</a>
+            </div>
           </div>
         </div>
       </footer>

--- a/packages/common/src/components/FooterLink.jsx
+++ b/packages/common/src/components/FooterLink.jsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Kernel
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React from 'react'
+
+export default function FooterLink(props) {
+  const { textColor } = props
+  const { href, title } = props.link
+
+  return (
+    <a
+      className={`${textColor} px-3 py-4 lg:px-6 lg:py-2 flex items-center text-sm lowercase font-bold`}
+      href={href}
+    >
+      {title}
+    </a>
+  )
+}

--- a/packages/common/src/index.js
+++ b/packages/common/src/index.js
@@ -17,6 +17,7 @@ import { ServicesProvider, useServices } from './contexts/ServicesContext.js'
 import Footer from './components/Footer'
 import Navbar from './components/Navbar'
 import NavbarLink from './components/NavbarLink'
+import FooterLink from './components/FooterLink'
 import Alert from './components/Alert'
 import Loading from './components/Loading'
 
@@ -26,6 +27,6 @@ import linesVector from './assets/images/lines.png'
 export {
   jwtService, rpcClient,
   ServicesProvider, useServices,
-  Footer, Navbar, NavbarLink, Alert, Loading,
+  Footer, FooterLink, Navbar, NavbarLink, Alert, Loading,
   linesVector
 }

--- a/packages/explorer/src/views/Browse.js
+++ b/packages/explorer/src/views/Browse.js
@@ -14,7 +14,7 @@ import AppConfig from 'App.config'
 
 const INITIAL_STATE = { error: '', loading: true, profiles: {}, projects: {} }
 
-const actions = { }
+const actions = {}
 
 Object.keys(INITIAL_STATE)
   .forEach((key) => {
@@ -150,9 +150,7 @@ const Page = () => {
           </div>
         </div>
       </div>
-      <Footer backgroundColor='bg-kernel-dark' textColor='text-kernel-white'>
-        built at <a href='https://kernel.community/' className='text-kernel-green-light'>KERNEL</a>
-      </Footer>
+      <Footer backgroundColor='bg-kernel-dark' textColor='text-kernel-white'></Footer>
     </div>
   )
 }

--- a/packages/profile/src/views/Profile.jsx
+++ b/packages/profile/src/views/Profile.jsx
@@ -208,14 +208,12 @@ const Profile = () => {
               <Switch
                 checked={state.consentToggleEnabled}
                 onChange={changeConsentToggle}
-                className={`${
-                  state.consentToggleEnabled ? 'bg-kernel-green-dark' : 'bg-gray-200'
-                } relative inline-flex h-6 w-9 items-center rounded-full`}
+                className={`${state.consentToggleEnabled ? 'bg-kernel-green-dark' : 'bg-gray-200'
+                  } relative inline-flex h-6 w-9 items-center rounded-full`}
               >
                 <span
-                  className={`transform transition ease-in-out duration-200 ${
-                    state.consentToggleEnabled ? 'translate-x-4' : 'translate-x-1'
-                  } inline-block h-4 w-4 transform rounded-full bg-white`}
+                  className={`transform transition ease-in-out duration-200 ${state.consentToggleEnabled ? 'translate-x-4' : 'translate-x-1'
+                    } inline-block h-4 w-4 transform rounded-full bg-white`}
                 />
               </Switch>
               <Switch.Label passive className='ml-2 align-top'>Make my information available to others</Switch.Label>
@@ -233,9 +231,7 @@ const Profile = () => {
 
         </form>
       </div>
-      <Footer backgroundColor='bg-kernel-dark' textColor='text-kernel-white'>
-        built at <a href='https://kernel.community/' className='text-kernel-green-light'>KERNEL</a>
-      </Footer>
+      <Footer backgroundColor='bg-kernel-dark' textColor='text-kernel-white'></Footer>
     </div>
   )
 }

--- a/packages/projects/src/components/Page.jsx
+++ b/packages/projects/src/components/Page.jsx
@@ -7,9 +7,7 @@
  */
 
 import { Link } from 'react-router-dom'
-
 import { Footer, Navbar } from '@kernel/common'
-
 import AppConfig from 'App.config'
 
 const editMenuItem = ({ projectHandle }) => {
@@ -40,9 +38,7 @@ const Page = ({ projectHandle, children }) => {
       <div className='mb-auto mx-24 py-24'>
         {children}
       </div>
-      <Footer backgroundColor='bg-kernel-dark' textColor='text-kernel-white'>
-        built at <a href='https://kernel.community/' className='text-kernel-green-light'>KERNEL</a>
-      </Footer>
+      <Footer backgroundColor='bg-kernel-dark' textColor='text-kernel-white'></Footer>
     </div>
   )
 }


### PR DESCRIPTION
Closes #19 

Added default Footer links and adjusted Explorer, Profile, Projects, and Wallet workspaces to use the default.
Default can be overridden by adding custom children (<a/>) elements into the Footer in the app. Children which do not have `href` are ignored.