### PR TITLE
Unprofile: add avatar image upload

### DIFF
--- a/packages/explorer/src/views/Browse.js
+++ b/packages/explorer/src/views/Browse.js
@@ -102,12 +102,20 @@ const Page = () => {
                   const created = Date.now() - meta.created
                   return (
                     <li key={meta.id} className='text-gray-700 py-4'>
-                      <p><small>{humanize(created)}</small></p>
-                      <p><small>{profile.memberId}</small></p>
                       <p><b>{profile.name}</b> ({profile.pronouns})</p>
+
+                      {profile.avatar &&
+                        <div className='my-2 mx-auto grid place-items-center box-border rounded-full h-32 w-32'>
+                          <img
+                            src={profile.avatar} alt='avatar'
+                            className='w-full h-full object-cover rounded-full'
+                          />
+                        </div>}
                       <p>{profile.city} - {profile.company}</p>
                       <p>{profile.bio}</p>
                       <p>{profile.email} - {profile.twitter}</p>
+                      <p><small>{profile.memberId}</small></p>
+                      <p><small>{humanize(created)}</small></p>
                     </li>
                   )
                 })}

--- a/packages/profile/package.json
+++ b/packages/profile/package.json
@@ -17,6 +17,7 @@
     "ethers": "5.6.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-image-file-resizer": "^0.4.8",
     "react-router-dom": "^6.2.2",
     "react-scripts": "5.0.0",
     "sass": "^1.50.0",

--- a/packages/profile/src/index.scss
+++ b/packages/profile/src/index.scss
@@ -1,3 +1,9 @@
 @tailwind base;
+
+@layer base {
+  a {
+    @apply text-kernel-eggplant-light
+  }
+}
 @tailwind components;
 @tailwind utilities;

--- a/packages/profile/src/views/Profile.jsx
+++ b/packages/profile/src/views/Profile.jsx
@@ -66,12 +66,14 @@ const reducer = (state, action) => {
 // tries to get the payload out of the event and dispatch it
 const change = (dispatch, type, e) => {
   try {
+    const target = e.target
+
     if (type === 'avatar') {
-      onAvatarChange(dispatch, e)
-      e.target.value = null // reset so onChange will fire even for same image
+      onAvatarChange(dispatch, target)
+      target.value = null // reset so onChange will fire even for same image
       return
     }
-    const target = e.target
+
     const payload = target.type === 'checkbox' ? target.checked : target.value
     dispatch({ type, payload })
   } catch (error) {
@@ -79,15 +81,15 @@ const change = (dispatch, type, e) => {
   }
 }
 
-const onAvatarChange = (dispatch, e) => {
-  if (e.target.files.length === 0) {
+const onAvatarChange = (dispatch, target) => {
+  if (target.files.length === 0) {
     return
   }
 
   const { maxHeight, maxWidth, format, quality, rotation, outputType } = AVATAR_CONFIG
 
   Resizer.imageFileResizer(
-    e.target.files[0],
+    target.files[0],
     maxWidth,
     maxHeight,
     format,
@@ -266,9 +268,9 @@ const Profile = () => {
             <div className={`my-8 grid place-items-center box-border rounded-full h-80 w-80
               ${state.avatar ? '' : 'border-dashed border-2 border-gray-400'}`}
             >
-              {value(state, 'avatar')
+              {state.avatar
                 ? <img
-                    src={value(state, 'avatar')} alt='avatar'
+                    src={state.avatar} alt='avatar'
                     className='w-80 h-80 object-cover rounded-full'
                   />
                 : <span className='text-gray-400'>add an image</span>}

--- a/packages/profile/src/views/Profile.jsx
+++ b/packages/profile/src/views/Profile.jsx
@@ -169,7 +169,12 @@ const ProfileAlert = ({ formStatus, errorMessage }) => {
     case 'submitting':
       return <Alert type='transparent'>Saving your changes...</Alert>
     case 'success':
-      return <Alert type='success'>Your changes have been saved!</Alert>
+      return (
+        <Alert type='success'>
+          Your changes have been saved!&nbsp;
+          <a href={getUrl('explorer')}>Start exploring.</a>
+        </Alert>
+      )
     case 'error':
       return <Alert type='danger'>Something went wrong. {errorMessage}</Alert>
     default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11117,6 +11117,11 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-image-file-resizer@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/react-image-file-resizer/-/react-image-file-resizer-0.4.8.tgz#85f4ae4469fd2867d961568af660ef403d7a79af"
+  integrity sha512-Ue7CfKnSlsfJ//SKzxNMz8avDgDSpWQDOnTKOp/GNRFJv4dO9L5YGHNEnj40peWkXXAK2OK0eRIoXhOYpUzUTQ==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
+ Uses `react-image-file-resizer` to auto-resize image to a max of 500x500. I can probably do it without the library (via `canvas`), but it would be rather verbose.
+ Shows avatar in Explorer
+ Unrelated extra: adds link from Unprofile success alert to Explorer

Addresses #15 

Empty state:
![Screen Shot 2022-06-07 at 1 17 55 AM](https://user-images.githubusercontent.com/4686089/172305519-a7bbac32-2c6c-4c1b-839a-a10e38ddfa5a.png)

Populated state:
![Screen Shot 2022-06-07 at 1 17 36 AM](https://user-images.githubusercontent.com/4686089/172305514-9226c60c-bde7-48fd-8ede-40ce6f3c5012.png)

Explorer:
![Screen Shot 2022-06-07 at 1 52 08 AM](https://user-images.githubusercontent.com/4686089/172305734-c10a5fd7-8f63-4935-9516-452cbf5b2677.png)
