### PR TITLE
Provide context for applications

### DIFF
--- a/packages/applications/src/App.js
+++ b/packages/applications/src/App.js
@@ -8,10 +8,11 @@
 
 import React, { Suspense, lazy } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
-import { ServicesProvider, Loading, Login } from '@kernel/common'
+import { ServicesProvider, Loading } from '@kernel/common'
 
 import 'App.css'
 
+const Home = lazy(() => import('views/Home'))
 const Application = lazy(() => import('views/Application'))
 
 const App = () => {
@@ -20,7 +21,7 @@ const App = () => {
       <ServicesProvider>
         <Suspense fallback={<Loading />}>
           <Routes>
-            <Route path='/' element={<Login />} />
+            <Route path='/' element={<Home />} />
             <Route path='/apply' element={<Application />} />
           </Routes>
         </Suspense>

--- a/packages/applications/src/components/AppIntro.jsx
+++ b/packages/applications/src/components/AppIntro.jsx
@@ -7,22 +7,22 @@
  */
 
 const AppIntro = (onLogin) => {
-    return (
-        <>
-            <p className='my-4'>
-                This page will help you apply to Kernel: a custom educational community, made up by people from across the planet.
-            </p>
-            <p className='my-4'>
-                Our goal is to <strong>learn together</strong>. Our principles are <strong>do no harm</strong> and <strong>play, infinitely</strong>. Our primary method of learning is conversation. Together, this enables us to cultivate a culture of care.
-            </p>
-            <p className='my-4'>
-                There are a few steps to our application process. We encourage you to <strong>set aside ~20 minutes for this</strong>. Taking your time will help us get to know each other in a more wholesome way.
-            </p>
-            <p className='my-4'>
-                If you have already gone through the process, you can check your status by <button className='text-blue-600 visited:text-purple-600 cursor-pointer' onClick={onLogin}>clicking here</button>.
-            </p>
-        </>
-    )
+  return (
+    <>
+      <p className='my-4'>
+        This page will help you apply to Kernel: a custom educational community, made up by people from across the planet.
+      </p>
+      <p className='my-4'>
+        Our goal is to <strong>learn together</strong>. Our principles are <strong>do no harm</strong> and <strong>play, infinitely</strong>. Our primary method of learning is conversation. Together, this enables us to cultivate a culture of care.
+      </p>
+      <p className='my-4'>
+        There are a few steps to our application process. We encourage you to <strong>set aside ~20 minutes for this</strong>. Taking your time will help us get to know each other in a more wholesome way.
+      </p>
+      <p className='my-4'>
+        If you have already gone through the process, you can check your status by <button className='text-blue-600 visited:text-purple-600 cursor-pointer' onClick={onLogin}>clicking here</button>.
+      </p>
+    </>
+  )
 }
 
 export default AppIntro

--- a/packages/applications/src/components/AppIntro.jsx
+++ b/packages/applications/src/components/AppIntro.jsx
@@ -6,20 +6,23 @@
  *
  */
 
-const AppIntro = (onLogin) => {
+const AppIntro = ({ onLogin }) => {
   return (
     <>
       <p className='my-4'>
         This page will help you apply to Kernel: a custom educational community, made up by people from across the planet.
       </p>
       <p className='my-4'>
-        Our goal is to <strong>learn together</strong>. Our principles are <strong>do no harm</strong> and <strong>play, infinitely</strong>. Our primary method of learning is conversation. Together, this enables us to cultivate a culture of care.
+        Our goal is to <strong>learn together</strong>. Our principles are <strong>do no harm</strong> and <strong>play, infinitely</strong>.
+        Our primary method of learning is conversation. Together, this enables us to cultivate a culture of care.
       </p>
       <p className='my-4'>
-        There are a few steps to our application process. We encourage you to <strong>set aside ~20 minutes for this</strong>. Taking your time will help us get to know each other in a more wholesome way.
+        There are a few steps to our application process. We encourage you to <strong>set aside ~20 minutes for this</strong>.
+        Taking your time will help us get to know each other in a more wholesome way.
       </p>
       <p className='my-4'>
-        If you have already gone through the process, you can check your status by <button className='text-blue-600 visited:text-purple-600 cursor-pointer' onClick={onLogin}>clicking here</button>.
+        If you have already gone through the process, you can check your status by
+        <button className='text-blue-600 visited:text-purple-600 cursor-pointer' onClick={onLogin}>clicking here</button>.
       </p>
     </>
   )

--- a/packages/applications/src/components/Assurance.jsx
+++ b/packages/applications/src/components/Assurance.jsx
@@ -6,12 +6,15 @@
  *
  */
 
- const Assurance = () => (
-    <>
-        <p className='my-12'>
-            Even if you don't get in to Kernel immediately, you are free to read <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'>the syllabus</a>, learn from<a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'> everything we build</a>, watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>, and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>. Even better: creating your own, personal key-pair enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens, deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
-        </p>
-    </>
- )
+const Assurance = () => (
+  <>
+    <p className='my-12'>
+      It takes some time to go through the whole process, but Kernel Fellows are fellows for life. We know that each person who comes here is uniquely valuable. We wish to honour your time and effort, even if we are not able to host you well just yet.
+    </p>
+    <p className='my-12'>
+      Even if you don't get in to Kernel immediately, you are free to read <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'>the syllabus</a>, learn from<a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'> everything we build</a>, watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>, and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>. Even better: creating your own, personal key-pair enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens, deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
+    </p>
+  </>
+)
 
- export default Assurance
+export default Assurance

--- a/packages/applications/src/components/Assurance.jsx
+++ b/packages/applications/src/components/Assurance.jsx
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Kernel
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+ const Assurance = () => (
+    <>
+        <p className='my-12'>
+            Even if you don't get in to Kernel immediately, you are free to read <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'>the syllabus</a>, learn from<a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'> everything we build</a>, watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>, and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>. Even better: creating your own, personal key-pair enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens, deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
+        </p>
+    </>
+ )
+
+ export default Assurance

--- a/packages/applications/src/components/Assurance.jsx
+++ b/packages/applications/src/components/Assurance.jsx
@@ -9,10 +9,17 @@
 const Assurance = () => (
   <>
     <p className='my-12'>
-      It takes some time to go through the whole process, but Kernel Fellows are fellows for life. We know that each person who comes here is uniquely valuable. We wish to honour your time and effort, even if we are not able to host you well just yet.
+      It takes some time to go through the whole process, but Kernel Fellows are fellows for life.
+      We know that each person who comes here is uniquely valuable. We wish to honour your time and effort,
+      even if we are not able to host you well just yet.
     </p>
     <p className='my-12'>
-      Even if you don't get in to Kernel immediately, you are free to read <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'>the syllabus</a>, learn from<a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'> everything we build</a>, watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>, and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>. Even better: creating your own, personal key-pair enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens, deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
+      Even if you don't get in to Kernel immediately, you are free to read <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'>the syllabus</a>,
+      learn from <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'>everything we build</a>,
+      watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>,
+      and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>.
+      Even better: creating your own, personal key-pair enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens,
+      deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
     </p>
   </>
 )

--- a/packages/applications/src/components/Process.jsx
+++ b/packages/applications/src/components/Process.jsx
@@ -12,16 +12,23 @@ const Process = () => (
     <div className='columns-1 md:break-after-column'>
       <ol className='list-decimal px-12'>
         <li className='my-4'>
-          Create your keys. Keys are different to a username + password combination. Keys imply cryptography, which sounds complicated, but its really here to help you. Being given control of your 'private key' in a safe, educational environment means you can start your learning journey right now.
+          Create your keys. Keys are different to a username + password combination. Keys imply cryptography,
+          which sounds complicated, but its really here to help you. Being given control of your 'private key'
+          in a safe, educational environment means you can start your learning journey right now.
         </li>
         <li className='my-4'>
-          It's OK if you don't understand what creating your own keys means, or how to keep them safe. We're here to <strong>learn together</strong>. Follow along as best you can, and continue to the application form when prompted. Though only you see your keys, we can help you make new ones while keeping your data safe, private, and under your control.
+          It's OK if you don't understand what creating your own keys means, or how to keep them safe.
+          We're here to <strong>learn together</strong>. Follow along as best you can, and continue to
+          the application form when prompted. Though only you see your keys, we can help you make new ones
+          while keeping your data safe, private, and under your control.
         </li>
         <li className='my-4'>
-          Once you have created your keys, you will be redirected to an application form. Respond to the questions as best you can and click 'Submit' once you are happy.
+          Once you have created your keys, you will be redirected to an application form. Respond to the
+          questions as best you can and click 'Submit' once you are happy.
         </li>
         <li className='my-4'>
-          Come back here whenever you like, login, and check your status. We review applications on a rolling basis and will update you here and via email about any changes.
+          Come back here whenever you like, login, and check your status. We review applications on a
+          rolling basis and will update you here and via email about any changes.
         </li>
       </ol>
     </div>

--- a/packages/applications/src/components/Process.jsx
+++ b/packages/applications/src/components/Process.jsx
@@ -7,25 +7,25 @@
  */
 
 const Process = () => (
-    <>
-      <h1 className='py-4 text-4xl'>The Process</h1>
-      <div className='columns-1 md:break-after-column'>
-        <ol className='list-decimal px-12'>
-            <li className='my-4'>
-            Create your keys. Keys are different to a username + password combination. Keys imply cryptography, which sounds complicated, but its really here to help you. Being given control of your 'private key' in a safe, educational environment means you can start your learning journey right now.
-            </li>
-            <li className='my-4'>
-            It's OK if you don't understand what creating your own keys means, or how to keep them safe. We're here to <strong>learn together</strong>. Follow along as best you can, and continue to the application form when prompted. Though you are the only one who can see your keys, we can help you make new ones while keeping your data safe, private, and under your control.
-            </li>
-            <li className='my-4'>
-            Once you have created your keys, you will be redirected to an application form. Respond to the questions as best you can and click 'Submit' once you are happy.
-            </li>
-            <li className='my-4'>
-            Come back here whenever you like, login, and check your status. We review applications on a rolling basis and will update you here and via email about any changes.
-            </li>
-        </ol>
-      </div>
-    </>
-  )
-  
+  <>
+    <h1 className='py-4 text-4xl'>The Process</h1>
+    <div className='columns-1 md:break-after-column'>
+      <ol className='list-decimal px-12'>
+        <li className='my-4'>
+          Create your keys. Keys are different to a username + password combination. Keys imply cryptography, which sounds complicated, but its really here to help you. Being given control of your 'private key' in a safe, educational environment means you can start your learning journey right now.
+        </li>
+        <li className='my-4'>
+          It's OK if you don't understand what creating your own keys means, or how to keep them safe. We're here to <strong>learn together</strong>. Follow along as best you can, and continue to the application form when prompted. Though only you see your keys, we can help you make new ones while keeping your data safe, private, and under your control.
+        </li>
+        <li className='my-4'>
+          Once you have created your keys, you will be redirected to an application form. Respond to the questions as best you can and click 'Submit' once you are happy.
+        </li>
+        <li className='my-4'>
+          Come back here whenever you like, login, and check your status. We review applications on a rolling basis and will update you here and via email about any changes.
+        </li>
+      </ol>
+    </div>
+  </>
+)
+
 export default Process

--- a/packages/applications/src/components/Process.jsx
+++ b/packages/applications/src/components/Process.jsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Kernel
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+const Process = () => (
+    <>
+      <h1 className='py-4 text-4xl'>The Process</h1>
+      <div className='columns-1 md:break-after-column'>
+        <ol className='list-decimal px-12'>
+            <li className='my-4'>
+            Create your keys. Keys are different to a username + password combination. Keys imply cryptography, which sounds complicated, but its really here to help you. Being given control of your 'private key' in a safe, educational environment means you can start your learning journey right now.
+            </li>
+            <li className='my-4'>
+            It's OK if you don't understand what creating your own keys means, or how to keep them safe. We're here to <strong>learn together</strong>. Follow along as best you can, and continue to the application form when prompted. Though you are the only one who can see your keys, we can help you make new ones while keeping your data safe, private, and under your control.
+            </li>
+            <li className='my-4'>
+            Once you have created your keys, you will be redirected to an application form. Respond to the questions as best you can and click 'Submit' once you are happy.
+            </li>
+            <li className='my-4'>
+            Come back here whenever you like, login, and check your status. We review applications on a rolling basis and will update you here and via email about any changes.
+            </li>
+        </ol>
+      </div>
+    </>
+  )
+  
+export default Process

--- a/packages/applications/src/views/Home.jsx
+++ b/packages/applications/src/views/Home.jsx
@@ -12,88 +12,87 @@ import { useServices, Navbar, linesVector } from '@kernel/common'
 import AppConfig from 'App.config'
 
 const Home = () => {
-    const navigate = useNavigate()
-    const { walletLogin } = useServices()
+  const navigate = useNavigate()
+  const { walletLogin } = useServices()
 
-    const handleLogin = async () => {
-        const user = await walletLogin()
-        if (user.role <= AppConfig.minRole) {
-        const homeUrl = AppConfig.homeUrl || '/'
-        return navigate(homeUrl)
-        }
-        navigate('/')
+  const handleLogin = async () => {
+    const user = await walletLogin()
+    if (user.role <= AppConfig.minRole) {
+      const homeUrl = AppConfig.homeUrl || '/'
+      return navigate(homeUrl)
     }
+    navigate('/')
+  }
 
-    return (
-        <div>
-        <Navbar
-            title={AppConfig.appTitle}
-            logoUrl={AppConfig.logoUrl}
-            backgroundColor='bg-kernel-dark' textColor='text-kernel-white'
-        />
-        <main className='overflow-hidden'>
-            <div className='relative'>
-                <div className='hidden lg:block lg:fixed lg:-top-24 lg:-left-52 lg:z-0'>
-                    <img alt='kernel fingerprint' src={linesVector} width={383} height={412} />
-                </div>
-                <div className='hidden lg:block lg:fixed lg:-top-12 lg:-right-52 lg:z-0'>
-                    <img alt='kernel fingerprint' src={linesVector} width={442} height={476} />
-                </div>
-            </div>
-            <section className='absolute w-full h-screen'>
-            <div className='container mx-auto px-4 h-full'>
-                <div className='flex content-center items-center justify-center h-screen'>
-                <div className='w-full lg:w-3/4 px-4'>
-                    <div className='relative flex flex-col min-w-0 break-words w-full mb-6'>
-                        <p className='text-center text-4xl md:text-6xl my-6'>
-                            You found us! Welcome.
-                        </p>
-                        <div className='text-lg'>
-                            <p className='my-4'>
-                                This page will help you apply to Kernel: a custom educational community, made up by people from across the planet.  
-                            </p>
-                            <p className='my-4'>
-                                Our goal is to <strong>learn together</strong>. Our principles are <strong>do no harm</strong> and <strong>play, infinitely</strong>. Our primary method of learning is conversation. Together, this enables us to cultivate a culture of care.
-                            </p>
-                            <p className='my-4'>
-                                There are a few steps to our application process. We encourage you to <strong>set aside ~30 minutes for this</strong>. Taking your time will help us get to know each other in a more wholesome way.
-                            </p>
-                            <ol className='list-decimal px-12'>
-                                <li className='my-4'>
-                                    Create an account. This 'account' is really a <strong>key-pair</strong>, rather than the usual username + password combination. Being given control of your 'private key' in a safe, educational environment means you can start your learning journey right now.
-                                </li>
-                                <li className='my-4'>
-                                    It's OK if you don't understand what creating your own keys means, or how to keep them safe. We're here to <strong>learn together</strong>. Follow along as best you can, and continue to the application form when prompted. Though you are the only one who can see your keys, we can help you make new ones while keeping your data safe, private, and under your control.
-                                </li>
-                                <li className='my-4'>
-                                    Once you have created your keys, you will be redirected to an application form. Respond to the questions as best you can and click 'Submit' once you are happy.
-                                </li>
-                                <li className='my-4'>
-                                    Come back here whenever you like, login with your new account, and check your status. We review applications on a rolling basis and will update you here and via email about any changes.
-                                </li>
-                            </ol>
-                            <p className='my-12'>
-                                Even if you don't get in to Kernel immediately, you are free to read <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'>the syllabus</a>, learn from<a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'> everything we build</a>, watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>, and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>. Even better: creating your own, personal key-pair enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens, deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
-                            </p>
-                        </div>
-                        <div className='text-center mx-auto shadow-lg rounded-lg bg-gray-300 border-0 lg:w-80'>
-                            <button
-                                className='bg-gray-900 text-white active:bg-gray-700 text-sm font-bold uppercase px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 w-full'
-                                onClick={handleLogin}
-                                type='button'
-                            >
-                                Create your Kernel Account
-                            </button>
-                        </div>
-                    </div>
-                </div>
-                </div>
-            </div>
-            </section>
-        </main>
+  return (
+    <div>
+      <Navbar
+        title={AppConfig.appTitle}
+        logoUrl={AppConfig.logoUrl}
+        backgroundColor='bg-kernel-dark' textColor='text-kernel-white'
+      />
+      <main className='overflow-hidden'>
+        <div className='relative'>
+          <div className='hidden lg:block lg:fixed lg:-top-24 lg:-left-52 lg:z-0'>
+            <img alt='kernel fingerprint' src={linesVector} width={383} height={412} />
+          </div>
+          <div className='hidden lg:block lg:fixed lg:-top-12 lg:-right-52 lg:z-0'>
+            <img alt='kernel fingerprint' src={linesVector} width={442} height={476} />
+          </div>
         </div>
-    )
+        <section className='absolute w-full h-screen'>
+          <div className='container mx-auto px-4 h-full'>
+            <div className='flex content-center items-center justify-center h-screen'>
+              <div className='w-full lg:w-3/4 px-4'>
+                <div className='relative flex flex-col min-w-0 break-words w-full mb-6'>
+                  <p className='text-center text-4xl md:text-6xl my-6'>
+                    You found us! Welcome.
+                  </p>
+                  <div className='text-lg'>
+                    <p className='my-4'>
+                      This page will help you apply to Kernel: a custom educational community, made up by people from across the planet.
+                    </p>
+                    <p className='my-4'>
+                      Our goal is to <strong>learn together</strong>. Our principles are <strong>do no harm</strong> and <strong>play, infinitely</strong>. Our primary method of learning is conversation. Together, this enables us to cultivate a culture of care.
+                    </p>
+                    <p className='my-4'>
+                      There are a few steps to our application process. We encourage you to <strong>set aside ~30 minutes for this</strong>. Taking your time will help us get to know each other in a more wholesome way.
+                    </p>
+                    <ol className='list-decimal px-12'>
+                      <li className='my-4'>
+                        Create an account. This 'account' is really a <strong>key-pair</strong>, rather than the usual username + password combination. Being given control of your 'private key' in a safe, educational environment means you can start your learning journey right now.
+                      </li>
+                      <li className='my-4'>
+                        It's OK if you don't understand what creating your own keys means, or how to keep them safe. We're here to <strong>learn together</strong>. Follow along as best you can, and continue to the application form when prompted. Though you are the only one who can see your keys, we can help you make new ones while keeping your data safe, private, and under your control.
+                      </li>
+                      <li className='my-4'>
+                        Once you have created your keys, you will be redirected to an application form. Respond to the questions as best you can and click 'Submit' once you are happy.
+                      </li>
+                      <li className='my-4'>
+                        Come back here whenever you like, login with your new account, and check your status. We review applications on a rolling basis and will update you here and via email about any changes.
+                      </li>
+                    </ol>
+                    <p className='my-12'>
+                      Even if you don't get in to Kernel immediately, you are free to read <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'>the syllabus</a>, learn from<a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'> everything we build</a>, watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>, and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>. Even better: creating your own, personal key-pair enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens, deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
+                    </p>
+                  </div>
+                  <div className='text-center mx-auto shadow-lg rounded-lg bg-gray-300 border-0 lg:w-80'>
+                    <button
+                      className='bg-gray-900 text-white active:bg-gray-700 text-sm font-bold uppercase px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 w-full'
+                      onClick={handleLogin}
+                      type='button'
+                    >
+                      Create your Kernel Account
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  )
 }
 
 export default Home
- 

--- a/packages/applications/src/views/Home.jsx
+++ b/packages/applications/src/views/Home.jsx
@@ -15,8 +15,8 @@ import Process from 'components/Process'
 import Assurance from 'components/Assurance'
 
 const HOMESTATE = Object.freeze({
-  INTRO: 0, 
-  PROCESS: 1, 
+  INTRO: 0,
+  PROCESS: 1,
   ASSURANCE: 2
 })
 
@@ -39,8 +39,8 @@ const Home = () => {
   const handleLogin = async () => {
     const user = await walletLogin()
     if (user.role <= AppConfig.minRole) {
-        const homeUrl = AppConfig.homeUrl || '/'
-        return navigate(homeUrl)
+      const homeUrl = AppConfig.homeUrl || '/'
+      return navigate(homeUrl)
     }
     navigate('/')
   }
@@ -65,35 +65,37 @@ const Home = () => {
           <div className='container mx-auto px-4'>
             <div className='flex content-center items-center justify-center'>
               <div className='w-full lg:w-3/4 px-4'>
-                <div className='relative flex flex-col min-w-0 break-words w-full my-20'>
+                <div className='relative flex flex-col min-w-0 break-words w-full lg:w-3/4 lg:mx-auto my-24'>
                   <p className='text-center text-4xl md:text-6xl my-10'>
                     You found us! Welcome.
                   </p>
                   <div className='text-lg'>
-                    <div key={homeState} className={`transition-all duration-400 ${fade ? "opacity-0" : "opacity-100"}`}>
-                      { homeState === HOMESTATE.INTRO && <AppIntro onLogin={handleLogin} /> }  
-                      { homeState === HOMESTATE.PROCESS && <Process /> }
-                      { homeState === HOMESTATE.ASSURANCE && <Assurance /> }
+                    <div key={homeState} className={`transition-all duration-400 ${fade ? 'opacity-0' : 'opacity-100'}`}>
+                      {homeState === HOMESTATE.INTRO && <AppIntro onLogin={handleLogin} />}
+                      {homeState === HOMESTATE.PROCESS && <Process />}
+                      {homeState === HOMESTATE.ASSURANCE && <Assurance />}
                     </div>
                     {/** Navigation Buttons */}
                     <div className='flex flex-row flex-end justify-center align-center'>
-                      {homeState > HOMESTATE.INTRO && <button
-                        className='bg-gray-900 text-white active:bg-gray-700 text-sm font-bold uppercase px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1'
-                        type='button'
-                        onClick={() => updateHomeState(homeState-1)}
-                      >
-                        Back
-                      </button>}
-                      {homeState < HOMESTATE.ASSURANCE && <button
-                        className='bg-gray-900 text-white active:bg-gray-700 text-sm font-bold uppercase px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1'
-                        type='button'
-                        onClick={() => updateHomeState(homeState+1)}
-                      >
-                        { homeState === HOMESTATE.INTRO ? "Begin" : "Next" }
-                      </button>}
+                      {homeState > HOMESTATE.INTRO &&
+                        <button
+                          className='bg-gray-900 text-white active:bg-gray-700 text-sm font-bold uppercase px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1'
+                          type='button'
+                          onClick={() => updateHomeState(homeState - 1)}
+                        >
+                          Back
+                        </button>}
+                      {homeState < HOMESTATE.ASSURANCE &&
+                        <button
+                          className='bg-gray-900 text-white active:bg-gray-700 text-sm font-bold uppercase px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1'
+                          type='button'
+                          onClick={() => updateHomeState(homeState + 1)}
+                        >
+                          {homeState === HOMESTATE.INTRO ? 'Begin' : 'Next'}
+                        </button>}
                       {/** Create Your Keys CTA */}
-                      { 
-                        homeState === HOMESTATE.ASSURANCE && 
+                      {
+                        homeState === HOMESTATE.ASSURANCE &&
                           <button
                             className='bg-gray-900 text-white active:bg-gray-700 text-sm font-bold uppercase px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1'
                             onClick={handleLogin}
@@ -101,11 +103,11 @@ const Home = () => {
                           >
                             Create your keys
                           </button>
-                      } 
+                      }
                     </div>
-                    
+
                   </div>
-                  
+
                 </div>
               </div>
             </div>

--- a/packages/applications/src/views/Home.jsx
+++ b/packages/applications/src/views/Home.jsx
@@ -10,6 +10,8 @@ import { useNavigate } from 'react-router-dom'
 import { useServices, Navbar, linesVector } from '@kernel/common'
 
 import AppConfig from 'App.config'
+import Process from 'components/Process'
+import Assurance from 'components/Assurance'
 
 const Home = () => {
   const navigate = useNavigate()
@@ -40,12 +42,12 @@ const Home = () => {
             <img alt='kernel fingerprint' src={linesVector} width={442} height={476} />
           </div>
         </div>
-        <section className='absolute w-full h-screen'>
-          <div className='container mx-auto px-4 h-full'>
-            <div className='flex content-center items-center justify-center h-screen'>
+        <section className='absolute w-full'>
+          <div className='container mx-auto px-4'>
+            <div className='flex content-center items-center justify-center'>
               <div className='w-full lg:w-3/4 px-4'>
-                <div className='relative flex flex-col min-w-0 break-words w-full mb-6'>
-                  <p className='text-center text-4xl md:text-6xl my-6'>
+                <div className='relative flex flex-col min-w-0 break-words w-full my-20'>
+                  <p className='text-center text-4xl md:text-6xl my-10'>
                     You found us! Welcome.
                   </p>
                   <div className='text-lg'>
@@ -56,25 +58,13 @@ const Home = () => {
                       Our goal is to <strong>learn together</strong>. Our principles are <strong>do no harm</strong> and <strong>play, infinitely</strong>. Our primary method of learning is conversation. Together, this enables us to cultivate a culture of care.
                     </p>
                     <p className='my-4'>
-                      There are a few steps to our application process. We encourage you to <strong>set aside ~30 minutes for this</strong>. Taking your time will help us get to know each other in a more wholesome way.
+                      There are a few steps to our application process. We encourage you to <strong>set aside ~20 minutes for this</strong>. Taking your time will help us get to know each other in a more wholesome way.
                     </p>
-                    <ol className='list-decimal px-12'>
-                      <li className='my-4'>
-                        Create your keys. Keys are different to a username + password combination. Keys imply cryptography, which sounds complicated, but its really just here to help you. Being given control of your 'private key' in a safe, educational environment means you can start your learning journey right now.
-                      </li>
-                      <li className='my-4'>
-                        It's OK if you don't understand what creating your own keys means, or how to keep them safe. We're here to <strong>learn together</strong>. Follow along as best you can, and continue to the application form when prompted. Though you are the only one who can see your keys, we can help you make new ones while keeping your data safe, private, and under your control.
-                      </li>
-                      <li className='my-4'>
-                        Once you have created your keys, you will be redirected to an application form. Respond to the questions as best you can and click 'Submit' once you are happy.
-                      </li>
-                      <li className='my-4'>
-                        Come back here whenever you like, login with your new account, and check your status. We review applications on a rolling basis and will update you here and via email about any changes.
-                      </li>
-                    </ol>
-                    <p className='my-12'>
-                      Even if you don't get in to Kernel immediately, you are free to read <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'>the syllabus</a>, learn from<a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'> everything we build</a>, watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>, and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>. Even better: creating your own, personal key-pair enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens, deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
+                    <p className='my-4'>
+                      If you have already gone through the process, you can check your status by <button className='text-blue-600 visited:text-purple-600 cursor-pointer' onClick={handleLogin}>clicking here</button>.
                     </p>
+                    <Process />
+                    <Assurance />
                   </div>
                   <div className='text-center mx-auto shadow-lg rounded-lg bg-gray-300 border-0 lg:w-80'>
                     <button

--- a/packages/applications/src/views/Home.jsx
+++ b/packages/applications/src/views/Home.jsx
@@ -60,7 +60,7 @@ const Home = () => {
                     </p>
                     <ol className='list-decimal px-12'>
                       <li className='my-4'>
-                        Create an account. This 'account' is really a <strong>key-pair</strong>, rather than the usual username + password combination. Being given control of your 'private key' in a safe, educational environment means you can start your learning journey right now.
+                        Create your keys. Keys are different to a username + password combination. Keys imply cryptography, which sounds complicated, but its really just here to help you. Being given control of your 'private key' in a safe, educational environment means you can start your learning journey right now.
                       </li>
                       <li className='my-4'>
                         It's OK if you don't understand what creating your own keys means, or how to keep them safe. We're here to <strong>learn together</strong>. Follow along as best you can, and continue to the application form when prompted. Though you are the only one who can see your keys, we can help you make new ones while keeping your data safe, private, and under your control.
@@ -82,7 +82,7 @@ const Home = () => {
                       onClick={handleLogin}
                       type='button'
                     >
-                      Create your Kernel Account
+                      Create your keys
                     </button>
                   </div>
                 </div>

--- a/packages/applications/src/views/Home.jsx
+++ b/packages/applications/src/views/Home.jsx
@@ -70,7 +70,7 @@ const Home = () => {
                     You found us! Welcome.
                   </p>
                   <div className='text-lg'>
-                    <div key={homeState} className={`transition-all duration-400 ${fade ? 'opacity-0' : 'opacity-100'}`}>
+                    <div key={homeState} className={`transition-opacity duration-700 ease-in-out ${fade ? 'opacity-0' : 'opacity-100'}`}>
                       {homeState === HOMESTATE.INTRO && <AppIntro onLogin={handleLogin} />}
                       {homeState === HOMESTATE.PROCESS && <Process />}
                       {homeState === HOMESTATE.ASSURANCE && <Assurance />}

--- a/packages/applications/src/views/Home.jsx
+++ b/packages/applications/src/views/Home.jsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Kernel
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useNavigate } from 'react-router-dom'
+import { useServices, Navbar, linesVector } from '@kernel/common'
+
+import AppConfig from 'App.config'
+
+const Home = () => {
+    const navigate = useNavigate()
+    const { walletLogin } = useServices()
+
+    const handleLogin = async () => {
+        const user = await walletLogin()
+        if (user.role <= AppConfig.minRole) {
+        const homeUrl = AppConfig.homeUrl || '/'
+        return navigate(homeUrl)
+        }
+        navigate('/')
+    }
+
+    return (
+        <div>
+        <Navbar
+            title={AppConfig.appTitle}
+            logoUrl={AppConfig.logoUrl}
+            backgroundColor='bg-kernel-dark' textColor='text-kernel-white'
+        />
+        <main className='overflow-hidden'>
+            <div className='relative'>
+                <div className='hidden lg:block lg:fixed lg:-top-24 lg:-left-52 lg:z-0'>
+                    <img alt='kernel fingerprint' src={linesVector} width={383} height={412} />
+                </div>
+                <div className='hidden lg:block lg:fixed lg:-top-12 lg:-right-52 lg:z-0'>
+                    <img alt='kernel fingerprint' src={linesVector} width={442} height={476} />
+                </div>
+            </div>
+            <section className='absolute w-full h-screen'>
+            <div className='container mx-auto px-4 h-full'>
+                <div className='flex content-center items-center justify-center h-screen'>
+                <div className='w-full lg:w-3/4 px-4'>
+                    <div className='relative flex flex-col min-w-0 break-words w-full mb-6'>
+                        <p className='text-center text-4xl md:text-6xl my-6'>
+                            You found us! Welcome.
+                        </p>
+                        <div className='text-lg'>
+                            <p className='my-4'>
+                                This page will help you apply to Kernel: a custom educational community, made up by people from across the planet.  
+                            </p>
+                            <p className='my-4'>
+                                Our goal is to <strong>learn together</strong>. Our principles are <strong>do no harm</strong> and <strong>play, infinitely</strong>. Our primary method of learning is conversation. Together, this enables us to cultivate a culture of care.
+                            </p>
+                            <p className='my-4'>
+                                There are a few steps to our application process. We encourage you to <strong>set aside ~30 minutes for this</strong>. Taking your time will help us get to know each other in a more wholesome way.
+                            </p>
+                            <ol className='list-decimal px-12'>
+                                <li className='my-4'>
+                                    Create an account. This 'account' is really a <strong>key-pair</strong>, rather than the usual username + password combination. Being given control of your 'private key' in a safe, educational environment means you can start your learning journey right now.
+                                </li>
+                                <li className='my-4'>
+                                    It's OK if you don't understand what creating your own keys means, or how to keep them safe. We're here to <strong>learn together</strong>. Follow along as best you can, and continue to the application form when prompted. Though you are the only one who can see your keys, we can help you make new ones while keeping your data safe, private, and under your control.
+                                </li>
+                                <li className='my-4'>
+                                    Once you have created your keys, you will be redirected to an application form. Respond to the questions as best you can and click 'Submit' once you are happy.
+                                </li>
+                                <li className='my-4'>
+                                    Come back here whenever you like, login with your new account, and check your status. We review applications on a rolling basis and will update you here and via email about any changes.
+                                </li>
+                            </ol>
+                            <p className='my-12'>
+                                Even if you don't get in to Kernel immediately, you are free to read <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'>the syllabus</a>, learn from<a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'> everything we build</a>, watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>, and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>. Even better: creating your own, personal key-pair enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens, deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
+                            </p>
+                        </div>
+                        <div className='text-center mx-auto shadow-lg rounded-lg bg-gray-300 border-0 lg:w-80'>
+                            <button
+                                className='bg-gray-900 text-white active:bg-gray-700 text-sm font-bold uppercase px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 w-full'
+                                onClick={handleLogin}
+                                type='button'
+                            >
+                                Create your Kernel Account
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                </div>
+            </div>
+            </section>
+        </main>
+        </div>
+    )
+}
+
+export default Home
+ 

--- a/packages/wallet/src/views/Register.jsx
+++ b/packages/wallet/src/views/Register.jsx
@@ -30,22 +30,21 @@ const Register = () => {
         </div>
         <div className='my-4 px-4 grid grid-cols-1 md:grid-cols-2 md:my-16 md:px-16'>
           <div>
-            <h3 className='text-center font-heading text-center text-3xl text-primary py-5'>First Time User</h3>
+            <h3 className='text-center font-heading text-center text-3xl text-primary py-5'>This is my first time</h3>
             <div className='text-center m-8 p-5'>
               <Link className='bg-kernel-dark text-kernel-white text-center w-full p-5 rounded shadow-md' to='/register/create'>
                 Create
               </Link>
             </div>
-            <p className='text-center m-4'>If this is the first time visiting us, you should first <strong>Create</strong> a new Kernel Wallet.</p>
+            <p className='text-center m-4'>If this is your first time visiting us, you should first <strong>Create</strong> a new Kernel Account.</p>
           </div>
           <div>
-            <h3 className='text-center font-heading text-center text-3xl text-primary py-5'>Returning User</h3>
+            <h3 className='text-center font-heading text-center text-3xl text-primary py-5'>I've done this before</h3>
             <div className='text-center m-8 p-5'>
               <Link className='bg-kernel-dark text-kernel-white text-center w-full p-5 rounded shadow-md' to='/register/import'>Import</Link>
             </div>
             <p className='text-center m-4'>
-              You should <strong>Import</strong> an existing Kernel Wallet on a different devices such
-              as Mobile phones, Laptops, etc.
+              You can <strong>Import</strong> an existing Kernel Account. This is useful if you want to use the same account on different devices like phones, laptops, etc.
             </p>
           </div>
         </div>

--- a/packages/wallet/src/views/Wallet.jsx
+++ b/packages/wallet/src/views/Wallet.jsx
@@ -42,7 +42,7 @@ const Wallet = () => {
               <span className='pr-2 before:block before:absolute before:-inset-1 before:-skew-y-3 before:bg-kernel-highlight relative inline-block cursor-pointer'>
                 <span className='relative text-primary'>
                   <span className='underline decoration-dotted'>
-                    Create an account
+                    Create a wallet
                   </span>
                 </span>
               </span>
@@ -52,7 +52,7 @@ const Wallet = () => {
               <span className='pl-2 before:block before:absolute before:-inset-1 before:skew-y-3 before:bg-kernel-yellow-light relative inline-block cursor-pointer'>
                 <span className='relative text-primary'>
                   <span className='underline decoration-dotted'>
-                    continue connecting
+                    log back in
                   </span>.
                 </span>
               </span>


### PR DESCRIPTION
This PR changes the Applications home page. It's intention is to provide new applicants with an idea of what to expect from the whole process.

1. I added a lot of copy which synthesizes Sal's drafts and Brennan's recent contributions.
2. I tried to use clear, simple and neutral language to describe creating a "Kernel Account". Please note that I have chosen "account" based on feedback from Boyana's tests. None of these were definitive, and we can continue testing different words for ease of understanding, but I do think having one word across the board is best. We don't like "wallet". "Portal" seems too far to reach at first for most people. "Account" seems like a descriptive middle ground.
3. I removed the Footer from the Applications page - the less inaccessible links we offer at first, the better.
4. I adapted a bit of copy on the wallet register page: removing "user" (we have "people" not "users") and removing strange capitalization.

In general, I wonder if this is now too many words for the first page :sweat_smile: I genuinely tried to keep it to as few as possible. Maybe the section about what else to do while you wait/if you don't get in can come after the submission of the form? It may be more contextual there and make this page less intimidating as a wall of text before you even begin...