### PR TITLE
Change field label "reason" to "purpose"

### DIFF
--- a/packages/applications/src/views/Application.jsx
+++ b/packages/applications/src/views/Application.jsx
@@ -16,7 +16,7 @@ import Intro from 'components/Intro'
 const FORM_INPUT = {
   name: { label: 'Name', tip: 'What can we call you?', tag: 'input' },
   email: { label: 'Email', tip: 'So we can send you updates.', tag: 'input' },
-  reason: { label: 'Reason', tip: 'Why do you want to be in Kernel?', tag: 'textarea' },
+  purpose: { label: 'Purpose', tip: 'Why do you want to be in Kernel?', tag: 'textarea' },
   interests: { label: 'Interests', tip: 'At Kernel, we learn through conversations organised by any fellow. What topics most inspire you to talk and listen? What are you really passionate about?', tag: 'textarea' },
   activities: { label: 'Activities', tip: 'What do you love doing? What makes you grateful to be alive?', tag: 'textarea' },
   urls: { label: 'Links', tip: 'Please share any links which best represent you (can be a song you like, a project you work on, or anything else between).', tag: 'textarea' }


### PR DESCRIPTION
In light of Ray's suggestion for a statement of purpose (linked below), I decided to try my hand at my first ever pull request. I think that the word purpose here better captures what we are trying to communicate by better accommodating non-propositional forms of knowing "Why do I want to be in Kernel?".

 https://kernel-community.slack.com/archives/C031ES44SA3/p1666458420993419?thread_ts=1666303810.572639&cid=C031ES44SA3