### PR TITLE
Sets us up for one flow, and begins work on better application status…

### DIFF
--- a/packages/applications/src/components/Assurance.jsx
+++ b/packages/applications/src/components/Assurance.jsx
@@ -9,17 +9,12 @@
 const Assurance = () => (
   <>
     <p className='my-12'>
-      It takes some time to go through the whole process, but Kernel Fellows are fellows for life.
-      We know that each person who comes here is uniquely valuable. We wish to honour your time and effort,
-      even if we are not able to host you well just yet.
+      Kernel Fellows are fellows for life. We know that each person who comes here is uniquely valuable. Thank you
+      for the passion and curiosity that has already brought you this far.
     </p>
     <p className='my-12'>
-      Even if you don't get in to Kernel immediately, you are free to read <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'>the syllabus</a>,
-      learn from <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'>everything we build</a>,
-      watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>,
-      and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>.
-      Even better: creating your own, personal key-pair enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens,
-      deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
+      Clicking the "Apply Now" button below will sign you in with your new wallet, after which you can begin filling in the form.
+      We look forward to welcoming you soon.
     </p>
   </>
 )

--- a/packages/applications/src/components/Intro.jsx
+++ b/packages/applications/src/components/Intro.jsx
@@ -15,7 +15,7 @@ const Intro = () => (
     <div className='columns-1 md:break-after-column'>
       <Paragraph>This application is the start of your Kernel Unprofile. Rather than project what you think others want to hear, we ask that you speak the truth with love. This is what serves our core goal, which is to <strong>learn together</strong>.</Paragraph>
       <Paragraph>What you write here will be visible to current fellows. We value honesty, sincerity, simplicity, and a diversity of skills and interests. <a className='text-blue-600 visited:text-purple-600' href='https://www.kernel.community/en/start/principled-people/' target='_blank' rel='noreferrer'>Our principles</a> are <strong>do no harm</strong> and <strong>play, infinitely</strong>.</Paragraph>
-      <Paragraph>The purpose of this form is to take care when getting to know each other, but we know that these forms can be stressful. We hope that you feel invited to explore and push the boundaries of your capabilities in Kernel in an authentic way. Stay true to yourself, and speak your truth with love. You are valuable just as you are.</Paragraph>
+      <Paragraph>The purpose of this form is to take care when getting to know each other, but we know that these forms can be stressful. We hope that you feel invited to explore and push your own boundaries in an authentic way. Remember, you are valuable just as you are.</Paragraph>
       <Paragraph>You can save your application and submit it whenever you are ready.</Paragraph>
     </div>
   </>

--- a/packages/applications/src/components/Process.jsx
+++ b/packages/applications/src/components/Process.jsx
@@ -11,25 +11,53 @@ const Process = () => (
     <h1 className='py-4 text-4xl'>The Process</h1>
     <div className='columns-1 md:break-after-column'>
       <ol className='list-decimal px-12'>
-        <li className='my-4'>
-          Create your keys. Keys are different to a username + password combination. Keys imply cryptography,
-          which sounds complicated, but its really here to help you. Being given control of your 'private key'
-          in a safe, educational environment means you can start your learning journey right now.
+        <li className='my-4 underline'>
+          <strong>You have already created a wallet</strong>
         </li>
-        <li className='my-4'>
-          It's OK if you don't understand what creating your own keys means, or how to keep them safe.
-          We're here to <strong>learn together</strong>. Follow along as best you can, and continue to
-          the application form when prompted. Though only you see your keys, we can help you make new ones
-          while keeping your data safe, private, and under your control.
+        <ul>
+          <li className='mx-8 my-2'>
+            If you haven't, it's not a problem. This page still applies to you, and you will be prompted to create a wallet when you begin.
+          </li>
+          <li className='mx-8 my-2'>
+            Wallets do not work like usernames and passwords: they work with "keys". Keys are special secrets: a unique string of letters
+            and numbers which give you access to your wallet. These keys are in the "json" file you downloaded when creating your wallet,
+            though you can't see them directly, because we encrypt that file with your password to provide an extra layer of security for you.
+          </li>
+          <li className='mx-8 my-2'>
+            It's OK if you don't understand what creating your own keys means, or how to keep them safe.
+            We're here to <strong>learn together</strong>. Follow along as best you can, and continue to
+            the application form when prompted. Though only you see your keys, we can help you make new ones
+            while keeping your data safe, private, and under your control.
+          </li>
+        </ul>
+        <li className='my-4 underline'>
+          <strong>Respond to the questions as best you can</strong>
         </li>
-        <li className='my-4'>
-          Once you have created your keys, you will be redirected to an application form. Respond to the
-          questions as best you can and click 'Submit' once you are happy.
+        <ul>
+          <li className='mx-8 my-2'>
+            In the next step, you will be taken to our application form. When you click the "Apply Now" button, you will be signed into the
+            application form with your new wallet, and you can respond to each of the questions.
+          </li>
+        </ul>
+        <li className='my-4 underline'>
+          <strong>Begin learning now!</strong>
         </li>
-        <li className='my-4'>
-          Come back here whenever you like, login, and check your status. We review applications on a
-          rolling basis and will update you here and via email about any changes.
+        <ul>
+          <li className='mx-8 my-2'>
+            All of our work, tools, and resources are free and open source. You do not need to wait for your application to be reviewed
+            in order to start learning. We'll provide the best links we can after you submit your application. You can also use all the tools
+            in the wallet you created right now: you do not need our permission.
+          </li>
+        </ul>
+        <li className='my-4 underline'>
+          <strong>Check your status</strong>
         </li>
+        <ul>
+          <li className='mx-8 my-2'>
+            Come back here whenever you like, sign in, and see where your application is. We review applications on a
+            rolling basis and will update you here and via email about any changes.
+          </li>
+        </ul>
       </ol>
     </div>
   </>

--- a/packages/applications/src/components/SuccessMessage.jsx
+++ b/packages/applications/src/components/SuccessMessage.jsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Kernel
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { getUrl } from '@kernel/common'
+
+const SuccessMessage = () => {
+  const walletLink = `${getUrl('wallet') + '/portal/overview'}`
+  return (
+    <div className='mb-auto mt-10 py-20 px-20 sm:px-40 lg:px-80'>
+      <h3 className='font-heading lg:text-5xl text-5xl text-primary lg:py-5'>
+        Success! You have submitted.
+      </h3>
+      <p className='my-8'>
+        Thank you so much for submitting an application. You should get an email from us shortly confirming receipt.
+      </p>
+      <p className='my-8'>
+        We do reviews on a rolling basis, and how long your review takes can therefore vary, depending on the time of year and how many
+        current fellows are available to review new applicants. We will communicate the status of your application both here and via email. Feel
+        free to log back into this app whenever you like to check your current status.
+      </p>
+      <p className='my-8'>
+        That said, you do not need to wait for a review in order to begin learning. All our tools are free and open source. You can
+        <a className='text-blue-600 visited:text-purple-600' href={walletLink}> return to the wallet</a> to begin learning by doing.
+        You can read<a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'> the syllabus</a>,
+        learn from <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'>everything we build</a>,
+        watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>,
+        and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>.
+        Even better: creating your own keys enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens,
+        deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
+      </p>
+    </div>
+  )
+}
+
+export default SuccessMessage

--- a/packages/applications/src/views/Application.jsx
+++ b/packages/applications/src/views/Application.jsx
@@ -8,10 +8,11 @@
 
 import { useEffect, useReducer } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useServices, Navbar, Footer, Alert, getUrl } from '@kernel/common'
+import { useServices, Navbar, Footer, Alert } from '@kernel/common'
 
 import AppConfig from 'App.config'
 import Intro from 'components/Intro'
+import SuccessMessage from 'components/SuccessMessage'
 
 const FORM_INPUT = {
   name: { label: 'Name', tip: 'What can we call you?', tag: 'input' },
@@ -157,35 +158,6 @@ const Input = ({ fieldName, label, tip, tag, state, dispatch }) => {
         type='text' disabled={disabled} className={`border-1 rounded w-full ${bgColorClass}`}
         value={value(state, fieldName)} onChange={change.bind(null, dispatch, fieldName)}
       />
-    </div>
-  )
-}
-
-const SuccessMessage = () => {
-  const walletLink = `${getUrl('wallet') + '/portal/overview'}`
-  return (
-    <div className='mb-auto mt-10 py-20 px-20 sm:px-40 lg:px-80'>
-      <h3 className='font-heading lg:text-5xl text-5xl text-primary lg:py-5'>
-        Success! You have submitted.
-      </h3>
-      <p className='my-8'>
-        Thank you so much for submitting an application. You should get an email from us shortly confirming receipt.
-      </p>
-      <p className='my-8'>
-        We do reviews on a rolling basis, and how long your review takes can therefore vary, depending on the time of year and how many
-        current fellows are available to review new applicants. We will communicate the status of your application both here and via email. Feel
-        free to log back into this app whenever you like to check your current status.
-      </p>
-      <p className='my-8'>
-        That said, you do not need to wait for a review in order to begin learning. All our tools are free and open source. You can
-        <a className='text-blue-600 visited:text-purple-600' href={walletLink}> return to the wallet</a> to begin learning by doing.
-        You can read<a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'> the syllabus</a>,
-        learn from <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'>everything we build</a>,
-        watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>,
-        and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>.
-        Even better: creating your own keys enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens,
-        deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
-      </p>
     </div>
   )
 }

--- a/packages/applications/src/views/Application.jsx
+++ b/packages/applications/src/views/Application.jsx
@@ -8,7 +8,7 @@
 
 import { useEffect, useReducer } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useServices, Navbar, Footer, Alert } from '@kernel/common'
+import { useServices, Navbar, Footer, Alert, getUrl } from '@kernel/common'
 
 import AppConfig from 'App.config'
 import Intro from 'components/Intro'
@@ -161,6 +161,35 @@ const Input = ({ fieldName, label, tip, tag, state, dispatch }) => {
   )
 }
 
+const SuccessMessage = () => {
+  const walletLink = `${getUrl('wallet') + '/portal/overview'}`
+  return (
+    <div className='mb-auto mt-10 py-20 px-20 sm:px-40 lg:px-80'>
+      <h3 className='font-heading lg:text-5xl text-5xl text-primary lg:py-5'>
+        Success! You have submitted.
+      </h3>
+      <p className='my-8'>
+        Thank you so much for submitting an application. You should get an email from us shortly confirming receipt.
+      </p>
+      <p className='my-8'>
+        We do reviews on a rolling basis, and how long your review takes can therefore vary, depending on the time of year and how many
+        current fellows are available to review new applicants. We will communicate the status of your application both here and via email. Feel
+        free to log back into this app whenever you like to check your current status.
+      </p>
+      <p className='my-8'>
+        That said, you do not need to wait for a review in order to begin learning. All our tools are free and open source. You can
+        <a className='text-blue-600 visited:text-purple-600' href={walletLink}> return to the wallet</a> to begin learning by doing.
+        You can read<a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/learn/' target='_blank' rel='noreferrer'> the syllabus</a>,
+        learn from <a className='text-blue-600 visited:text-purple-600' href='https://kernel.community/en/build' target='_blank' rel='noreferrer'>everything we build</a>,
+        watch <a className='text-blue-600 visited:text-purple-600' href='https://www.youtube.com/channel/UC2kUaSgR0L-uzGkNsOxSxzw' target='_blank' rel='noreferrer'>all our recordings</a>,
+        and use or adapt <a className='text-blue-600 visited:text-purple-600' href='https://github.com/kernel-community/' target='_blank' rel='noreferrer'>all our code </a>.
+        Even better: creating your own keys enables you to use many of our best tools right now. Your new account will help you learn how to mint tokens,
+        deploy your own contracts, decode transactions on a blockchain and much more. You do not need our permission to use it, and you can start right now...
+      </p>
+    </div>
+  )
+}
+
 const PageAlert = ({ formStatus, errorMessage }) => {
   switch (formStatus) {
     case 'saving':
@@ -169,8 +198,6 @@ const PageAlert = ({ formStatus, errorMessage }) => {
       return <Alert type='transparent'>Submitting your application...</Alert>
     case 'saved':
       return <Alert type='success'>Your application has been saved! Feel free to leave and come back later before submitting.</Alert>
-    case 'success':
-      return <Alert type='success'>Your application has been submitted! We will reach out with information about next steps.</Alert>
     case 'error':
       return <Alert type='danger'>{errorMessage}</Alert>
     default:
@@ -238,34 +265,39 @@ const Application = () => {
         menuLinks={AppConfig.navbar?.links}
         backgroundColor='bg-kernel-dark' textColor='text-kernel-white'
       />
-      <div className='mb-auto py-20 px-20 sm:px-40 lg:px-80'>
-        <Intro />
-        <form className='form-control w-full'>
-          {Object.entries(FORM_INPUT).map(([fieldName, { label, tag, tip }]) => {
-            return (
-              <Input key={fieldName} fieldName={fieldName} label={label} tag={tag} tip={tip} state={state} dispatch={dispatch} />
-            )
-          })}
-          <button
-            disabled={state.formStatus === 'submitting' || !state.editable}
-            onClick={save.bind(null, user, state, dispatch)}
-            className={`mt-6 mb-4 px-6 py-4 ${state.formStatus === 'submitting' || !state.editable ? 'bg-gray-300' : 'bg-kernel-green-dark'} text-kernel-white w-full rounded font-bold`}
-          >
-            Save
-          </button>
-          <button
-            disabled={state.formStatus === 'submitting'}
-            onClick={submit.bind(null, user, state, dispatch)}
-            className={`mt-6 mb-4 px-6 py-4 ${state.formStatus === 'submitting' || !state.editable ? 'bg-gray-300' : 'bg-kernel-green-dark'} text-kernel-white w-full rounded font-bold`}
-          >
-            Submit
-          </button>
+      {state.formStatus === 'success' || user.role < AppConfig.minRole
+        ? <SuccessMessage />
+        : <div className='mb-auto py-20 px-20 sm:px-40 lg:px-80'>
+          <Intro />
+          <form className='form-control w-full'>
+            {Object.entries(FORM_INPUT).map(([fieldName, { label, tag, tip }]) => {
+              return (
+                <Input key={fieldName} fieldName={fieldName} label={label} tag={tag} tip={tip} state={state} dispatch={dispatch} />
+              )
+            })}
+            <button
+              disabled={state.formStatus === 'submitting' || !state.editable}
+              onClick={save.bind(null, user, state, dispatch)}
+              className={`mt-6 mb-4 px-6 py-4 ${state.formStatus === 'submitting' || !state.editable ? 'bg-gray-300' : 'bg-kernel-green-dark'} text-kernel-white w-full rounded font-bold`}
+            >
+              Save
+            </button>
+            <button
+              disabled={state.formStatus === 'submitting'}
+              onClick={submit.bind(null, user, state, dispatch)}
+              className={`mt-6 mb-4 px-6 py-4 ${state.formStatus === 'submitting' || !state.editable ? 'bg-gray-300' : 'bg-kernel-green-dark'} text-kernel-white w-full rounded font-bold`}
+            >
+              Submit
+            </button>
 
-          <PageAlert formStatus={state.formStatus} errorMessage={state.errorMessage} />
+            <PageAlert formStatus={state.formStatus} errorMessage={state.errorMessage} />
 
-        </form>
-      </div>
-      <Footer />
+          </form>
+          {/* eslint-disable-next-line */}
+          </div>}
+      <Footer backgroundColor='bg-kernel-dark' textColor='text-kernel-white'>
+        built at <a href='https://kernel.community/' className='text-kernel-green-light'>KERNEL</a>
+      </Footer>
     </div>
   )
 }

--- a/packages/applications/src/views/Application.jsx
+++ b/packages/applications/src/views/Application.jsx
@@ -19,7 +19,7 @@ const FORM_INPUT = {
   email: { label: 'Email', tip: 'So we can send you updates.', tag: 'input' },
   reason: { label: 'Reason', tip: 'Why do you want to be in Kernel?', tag: 'textarea' },
   interests: { label: 'Interests', tip: 'What are you, personally, passionate about? What do you love doing? What makes you grateful to be alive?', tag: 'textarea' },
-  urls: { label: 'Life', tip: 'Is a puzzle to be solved, a garden to be cultivated, a game to be played? All, none, or something else? Tell us why. How do you lead your life?', tag: 'textarea' }
+  life: { label: 'Life', tip: 'Is a puzzle to be solved, a garden to be cultivated, a game to be played? All, none, or something else? Tell us why. How do you lead your life?', tag: 'textarea' }
 }
 
 const INITIAL_FORM_KEYS = [].concat(Object.keys(FORM_INPUT))

--- a/packages/applications/src/views/Home.jsx
+++ b/packages/applications/src/views/Home.jsx
@@ -101,13 +101,11 @@ const Home = () => {
                             onClick={handleLogin}
                             type='button'
                           >
-                            Create your keys
+                            Apply Now
                           </button>
                       }
                     </div>
-
                   </div>
-
                 </div>
               </div>
             </div>

--- a/packages/wallet/src/App.js
+++ b/packages/wallet/src/App.js
@@ -7,13 +7,16 @@
  */
 
 import React, { Suspense, lazy } from 'react'
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { ServicesProvider, Loading, Login } from '@kernel/common'
 
 import 'App.css'
 
 const Wallet = lazy(() => import('views/Wallet'))
 const Portal = lazy(() => import('views/Portal'))
+
+const Us = lazy(() => import('views/Us'))
+const Overview = lazy(() => import('views/Overview'))
 
 const Claim = lazy(() => import('views/Claim'))
 const Deploy = lazy(() => import('views/Deploy'))
@@ -35,14 +38,13 @@ const App = () => {
             <Route path='/' element={<Wallet />} />
             <Route path='/portal' element={<Portal />} />
 
+            <Route path='/portal/overview' element={<Overview />} />
+            <Route path='/portal/us' element={<Us />} />
+
             <Route path='/portal/claim' element={<Claim />} />
             <Route path='/portal/deploy' element={<Deploy />} />
             <Route path='/portal/mint' element={<Mint />} />
             <Route path='/portal/transact' element={<Transact />} />
-
-            <Route path='/portal/nfts' element={<Navigate to='/portal' replace />} />
-            <Route path='/portal/tokens' element={<Navigate to='/portal' replace />} />
-            <Route path='/portal/contracts' element={<Navigate to='/portal' replace />} />
 
             <Route path='/register' element={<Register />} />
             <Route path='/register/create' element={<Create />} />

--- a/packages/wallet/src/components/LinkCards.jsx
+++ b/packages/wallet/src/components/LinkCards.jsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Kernel
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Link } from 'react-router-dom'
+
+const EXTERNAL_ROLE = 2000
+
+const LinkCards = ({ user, cardConfig }) => {
+  const role = user ? user.role : EXTERNAL_ROLE
+  return cardConfig
+    .filter(({ minRole }) => role <= minRole)
+    .map((card, index) => {
+      const relative = card.url.startsWith('/')
+      const Tag = relative ? Link : 'a'
+      const link = `${card.active ? card.url : '#'}`
+      const props = relative ? { to: link } : { href: link }
+      return (
+        <Tag key={index} {...props}>
+          <div className={
+                `${card.active ? 'bg-kernel-dark text-kernel-white' : 'bg-kernel-grey'} p-5 rounded shadow-md`
+            }
+          >
+            <div className='text-xl mb-2'>{card.title}</div>
+            <div className='text-base mb-1'>{card.description}</div>
+          </div>
+        </Tag>
+      )
+    })
+}
+
+export default LinkCards

--- a/packages/wallet/src/views/Overview.jsx
+++ b/packages/wallet/src/views/Overview.jsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Kernel
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useServices, linesVector } from '@kernel/common'
+
+import Page from 'components/Page'
+import LinkCards from 'components/LinkCards'
+
+const EXTERNAL_ROLE = 2000
+
+const everyoneCards = [
+  {
+    title: '1. Claim',
+    description: 'Begin here with "test" money',
+    url: '/portal/claim',
+    active: true,
+    minRole: EXTERNAL_ROLE
+  },
+  {
+    title: '2. Transact',
+    description: 'Send money to your friends',
+    url: '/portal/transact',
+    active: true,
+    minRole: EXTERNAL_ROLE
+  },
+  {
+    title: '3. Deploy',
+    description: 'Make your own money!',
+    url: '/portal/deploy',
+    active: true,
+    minRole: EXTERNAL_ROLE
+  },
+  {
+    title: '4. Craft',
+    description: 'Create an NFT in one go',
+    url: '/portal/mint',
+    active: true,
+    minRole: EXTERNAL_ROLE
+  }
+]
+
+const Overview = () => {
+  const { currentUser } = useServices()
+  const user = currentUser()
+  return (
+    <Page>
+      <div className='relative'>
+        <div className='hidden lg:block lg:fixed lg:-top-24 lg:-left-52 lg:z-0'>
+          <img alt='kernel fingerprint' src={linesVector} width={383} height={412} />
+        </div>
+        <div className='hidden lg:block lg:fixed lg:-top-12 lg:-right-52 lg:z-0'>
+          <img alt='kernel fingerprint' src={linesVector} width={442} height={476} />
+        </div>
+      </div>
+      <div className='mt-32 mx-8 sm:mx-24 xl:mx-48'>
+        <div className='text-center'>
+          <div className='text-2xl my-4 text-secondary'>
+            Making money free
+          </div>
+          <hr />
+          <div className='my-4 lg:mx-72 text-secondary'>
+            This page will you help you start learning about all the things you can do with a non-custodial wallet. Begin by claiming some "test" Ether so that you can learn how to sign and understand transactions, create your own tokens, and mint your own on-chain NFTs!
+          </div>
+        </div>
+        <div>
+          <div className='grid grid-cols-1 md:grid-cols-2 my-20 md:gap-x-20 gap-y-8 md:px-24'>
+            <LinkCards user={user} cardConfig={everyoneCards} />
+          </div>
+        </div>
+      </div>
+    </Page>
+  )
+}
+
+export default Overview

--- a/packages/wallet/src/views/Portal.jsx
+++ b/packages/wallet/src/views/Portal.jsx
@@ -15,169 +15,13 @@ import { loadWallet } from 'common'
 import AppConfig from 'App.config'
 import Page from 'components/Page'
 
-const EXTERNAL_ROLE = 2000
-const MEMBER_ROLE = 1000
-
-const everyoneCards = [
-  {
-    title: 'Claim',
-    description: 'Get set up with some test ETH',
-    url: '/portal/claim',
-    active: true,
-    minRole: EXTERNAL_ROLE
-  },
-  {
-    title: 'Transact',
-    description: 'Understand how transactions work',
-    url: '/portal/transact',
-    active: true,
-    minRole: EXTERNAL_ROLE
-  },
-  {
-    title: 'Deploy',
-    description: 'Create your own token now',
-    url: '/portal/deploy',
-    active: true,
-    minRole: EXTERNAL_ROLE
-  },
-  {
-    title: 'Mint',
-    description: 'Create an NFT in one go',
-    url: '/portal/mint',
-    active: true,
-    minRole: EXTERNAL_ROLE
-  },
-  {
-    title: 'Contact',
-    description: 'Keep your friends\' addresses safe',
-    url: '/portal/contact',
-    active: false,
-    minRole: EXTERNAL_ROLE
-  },
-  {
-    title: 'Contribute',
-    description: 'Learn how to improve this with us',
-    url: '/portal/contribute',
-    active: false,
-    minRole: EXTERNAL_ROLE
-  },
-  {
-    title: 'Interact',
-    description: 'Explore all the best contracts',
-    url: '/portal/interact',
-    active: false,
-    minRole: EXTERNAL_ROLE
-  },
-  {
-    title: 'Develop',
-    description: 'Write your own code!',
-    url: '/portal/develop',
-    active: false,
-    minRole: EXTERNAL_ROLE
-  }
-]
-
-const memberCards = [
-  {
-    title: 'UnProfile',
-    description: 'Unprofile yourself',
-    url: getUrl('unprofile'),
-    active: true,
-    minRole: MEMBER_ROLE
-  },
-  {
-    title: 'Adventure',
-    description: 'Heed the call to adventure',
-    url: getUrl('adventures'),
-    active: true,
-    minRole: MEMBER_ROLE
-  },
-  {
-    title: 'Explore',
-    description: 'Connect with other Fellows',
-    url: getUrl('explorer'),
-    active: true,
-    minRole: MEMBER_ROLE
-  },
-  {
-    title: 'Groups',
-    description: 'Create and manage groups',
-    url: getUrl('groups'),
-    active: true,
-    minRole: MEMBER_ROLE
-  },
-  {
-    title: 'Proposals',
-    description: 'Create and vote on Proposals',
-    url: getUrl('proposals'),
-    active: true,
-    minRole: MEMBER_ROLE
-  },
-  {
-    title: 'Apply',
-    description: 'Apply to the Kernel Community',
-    url: getUrl('apply'),
-    active: true,
-    minRole: EXTERNAL_ROLE
-  },
-  {
-    title: 'Review',
-    description: 'Review applications and help expand the Kernel Community',
-    url: getUrl('review'),
-    active: true,
-    minRole: MEMBER_ROLE
-  },
-  {
-    title: 'Events',
-    description: 'Create and register for Events',
-    url: getUrl('events'),
-    active: true,
-    minRole: MEMBER_ROLE
-  },
-  {
-    title: 'Pages',
-    description: 'Create and manage Knowledge',
-    url: getUrl('www'),
-    active: true,
-    minRole: MEMBER_ROLE
-  },
-  {
-    title: 'Chat',
-    description: 'Horizontal conversations',
-    url: getUrl('chat'),
-    active: false,
-    minRole: MEMBER_ROLE
-  }
-]
-
-const LinkCards = ({ user, cardConfig }) => {
-  const role = user ? user.role : EXTERNAL_ROLE
-  return cardConfig
-    .filter(({ minRole }) => role <= minRole)
-    .map((card, index) => {
-      const relative = card.url.startsWith('/')
-      const Tag = relative ? Link : 'a'
-      const link = `${card.active ? card.url : '#'}`
-      const props = relative ? { to: link } : { href: link }
-      return (
-        <Tag key={index} {...props}>
-          <div className={
-            `${card.active ? 'bg-kernel-dark text-kernel-white' : 'bg-kernel-grey'} p-5 rounded shadow-md`
-          }
-          >
-            <div className='text-xl mb-2'>{card.title}</div>
-            <div className='text-base mb-1'>{card.description}</div>
-          </div>
-        </Tag>
-      )
-    })
-}
-
 const Portal = () => {
   const navigate = useNavigate()
 
   const { currentUser } = useServices()
   const user = currentUser()
+
+  const applyLink = getUrl('apply')
 
   const [nickname, setNickname] = useState('')
 
@@ -212,25 +56,29 @@ const Portal = () => {
           <div className='text-2xl my-4 text-secondary'>
             You are already valuable, just as you are.
           </div>
-          <div className='my-4 text-secondary'>
-            This portal will help you learn how to realize some of that value in the
-            world of web3. We're so happy you're with us.
-          </div>
         </div>
 
         <div className='my-4 px-4 grid grid-cols-1 md:grid-cols-2 md:my-16 md:px-16'>
           <div>
-            <h3 className='font-heading text-center text-3xl text-primary py-5'>For Everyone</h3>
-            <div className='grid grid-cols-1 md:grid-cols-2 md:gap-x-8 gap-y-8 border-0 md:border-r border-kernel-grey md:pr-12'>
-              <LinkCards user={user} cardConfig={everyoneCards} />
+            <h3 className='text-center font-heading text-center text-3xl text-primary py-5'>Let me explore myself</h3>
+            <div className='text-center m-8 p-5'>
+              <Link to='/portal/overview' className='bg-kernel-dark text-kernel-white text-center w-full p-5 rounded shadow-md'>
+                Go to Wallet
+              </Link>
             </div>
+            <p className='text-center m-4'>You do not need to join Kernel to use our tools. Start learning now...</p>
           </div>
           <div>
-            <h3 className='font-heading text-center text-3xl text-primary py-5'>Kernel Additions</h3>
-            <div className='grid grid-cols-1 md:grid-cols-2 md:gap-x-8 gap-y-8 md:pl-12'>
-              <LinkCards user={user} cardConfig={memberCards} />
+            <h3 className='text-center font-heading text-center text-3xl text-primary py-5'>Help me find the others</h3>
+            <div className='text-center m-8 p-5'>
+              {!user
+                ? <a href={applyLink} className='bg-kernel-dark text-kernel-white text-center w-full p-5 rounded shadow-md'>Apply to Kernel</a>
+                : <Link to='/portal/us' className='bg-kernel-dark text-kernel-white text-center w-full p-5 rounded shadow-md'>Explore Kernel</Link>}
             </div>
+            <p className='text-center m-4'>If you enjoy learning with others, come and find us...</p>
           </div>
+          <div />
+          <div />
         </div>
       </div>
     </Page>

--- a/packages/wallet/src/views/Portal.jsx
+++ b/packages/wallet/src/views/Portal.jsx
@@ -15,11 +15,14 @@ import { loadWallet } from 'common'
 import AppConfig from 'App.config'
 import Page from 'components/Page'
 
+const MEMBER_ROLE = 1000
+
 const Portal = () => {
   const navigate = useNavigate()
 
   const { currentUser } = useServices()
   const user = currentUser()
+  console.log('user', user)
 
   const applyLink = getUrl('apply')
 
@@ -71,7 +74,7 @@ const Portal = () => {
           <div>
             <h3 className='text-center font-heading text-center text-3xl text-primary py-5'>Help me find the others</h3>
             <div className='text-center m-8 p-5'>
-              {!user
+              {user.role > MEMBER_ROLE
                 ? <a href={applyLink} className='bg-kernel-dark text-kernel-white text-center w-full p-5 rounded shadow-md'>Apply to Kernel</a>
                 : <Link to='/portal/us' className='bg-kernel-dark text-kernel-white text-center w-full p-5 rounded shadow-md'>Explore Kernel</Link>}
             </div>

--- a/packages/wallet/src/views/Us.jsx
+++ b/packages/wallet/src/views/Us.jsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Kernel
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useServices, linesVector, getUrl } from '@kernel/common'
+
+import Page from 'components/Page'
+import LinkCards from 'components/LinkCards'
+
+const MEMBER_ROLE = 1000
+
+const memberCards = [
+  {
+    title: 'UnProfile',
+    description: 'Unprofile yourself',
+    url: getUrl('unprofile'),
+    active: true,
+    minRole: MEMBER_ROLE
+  },
+  {
+    title: 'Events',
+    description: 'Create and register for events',
+    url: getUrl('events'),
+    active: true,
+    minRole: MEMBER_ROLE
+  },
+  {
+    title: 'Adventure',
+    description: 'Heed the call to adventure',
+    url: getUrl('adventures'),
+    active: true,
+    minRole: MEMBER_ROLE
+  },
+  {
+    title: 'Explore',
+    description: 'Connect with other Fellows',
+    url: getUrl('explorer'),
+    active: true,
+    minRole: MEMBER_ROLE
+  },
+  {
+    title: 'Chat',
+    description: 'Horizontal conversations (coming soon)',
+    url: getUrl('chat'),
+    active: false,
+    minRole: MEMBER_ROLE
+  },
+  {
+    title: 'Proposals',
+    description: 'Create and vote on proposals',
+    url: getUrl('proposals'),
+    active: true,
+    minRole: MEMBER_ROLE
+  },
+  {
+    title: 'Review',
+    description: 'Find the others, welcome them in',
+    url: getUrl('review'),
+    active: true,
+    minRole: MEMBER_ROLE
+  },
+  {
+    title: 'Pages',
+    description: 'Create and curate wisdom',
+    url: getUrl('www'),
+    active: true,
+    minRole: MEMBER_ROLE
+  },
+  {
+    title: 'Groups',
+    description: 'Create and manage groups',
+    url: getUrl('groups'),
+    active: true,
+    minRole: MEMBER_ROLE
+  }
+]
+
+const Us = () => {
+  const { currentUser } = useServices()
+  const user = currentUser()
+  return (
+    <Page>
+      <div className='relative'>
+        <div className='hidden lg:block lg:fixed lg:-top-24 lg:-left-52 lg:z-0'>
+          <img alt='kernel fingerprint' src={linesVector} width={383} height={412} />
+        </div>
+        <div className='hidden lg:block lg:fixed lg:-top-12 lg:-right-52 lg:z-0'>
+          <img alt='kernel fingerprint' src={linesVector} width={442} height={476} />
+        </div>
+      </div>
+      <div className='mt-32 mx-8 sm:mx-24 xl:mx-48'>
+        <div className='text-center'>
+          <div className='text-2xl my-4 text-secondary'>
+            Welcome home. Love's infinite game begins here...
+          </div>
+          <hr />
+          <div className='my-4 lg:mx-72 text-secondary'>
+            This page shows you all the ways you can connect to others, contribute to Kernel, continue creating cool stuff, or find those special Kernel conversations which keep us all coming back to share time with one another.
+          </div>
+        </div>
+        <div>
+          <div className='grid grid-cols-1 my-20 md:grid-cols-3 md:gap-x-8 gap-y-8 md:pl-12'>
+            <LinkCards user={user} cardConfig={memberCards} />
+          </div>
+        </div>
+      </div>
+    </Page>
+  )
+}
+
+export default Us

--- a/packages/wallet/src/views/Wallet.jsx
+++ b/packages/wallet/src/views/Wallet.jsx
@@ -52,7 +52,7 @@ const Wallet = () => {
               <span className='pl-2 before:block before:absolute before:-inset-1 before:skew-y-3 before:bg-kernel-yellow-light relative inline-block cursor-pointer'>
                 <span className='relative text-primary'>
                   <span className='underline decoration-dotted'>
-                    log back in
+                    sign back in
                   </span>.
                 </span>
               </span>
@@ -63,20 +63,20 @@ const Wallet = () => {
               <div className='p-10 border rounded-md border-kernel-dark float-left mb-10 md:mb-0'>
                 <h2 className='font-heading text-3xl text-primary pb-6'>Learn</h2>
                 <p>
-                  This is a <strong>non-custodial wallet</strong>. It's OK if you're not sure what that means. Kernel is an open source learning community, and we're here to help each other <strong>understand</strong> and use our own <strong>keys</strong> to unlock doors to ever richer, <strong>shared</strong> truths.
+                  This is a <strong>non-custodial wallet</strong>. It's OK if you're not sure what that means. Kernel is an open source learning community, and we're here to <strong>learn together</strong>.
                 </p>
               </div>
               <div className='p-10 border rounded-md border-kernel-dark float-left mb-10 md:mb-0'>
                 <h2 className='font-heading text-3xl text-primary pb-6'>Play</h2>
                 <p>
-                  We call this a <strong>portal</strong> because it is about so much more than money. When we set out to learn together, rather than represent your "worth" with one number, we can discover much more <strong>wholesome</strong> ways of seeing and being.
+                  Your wallet is about so much more than money. When we set out to learn together, rather than represent your "worth" with one number, we can discover much more <strong>wholesome</strong> ways of seeing and being.
                 </p>
               </div>
             </div>
             <div className='pt-20'>
               <h1 className='font-heading text-5xl text-primary pb-6'>Help Us Help Each Other</h1>
               <p className='pb-10'>
-                Non-custodial means that you care for your keys, no-one else. Caring for our own keys empowers us, and it makes us <strong>responsible</strong>. That can be a lot to handle on your own, which is why we create open tools for communities of care. Our <strong>portal</strong> will help you:
+                Non-custodial means that you care for your keys, no-one else. Caring for our own keys empowers us, and it makes us <strong>responsible</strong>. That can be a lot to handle on your own, which is why we create open tools for communities of care. Our <strong>wallet</strong> will help you:
               </p>
               <ol className='list-decimal pl-10 pb-10 decoration-kernel-dark'>
                 <li className='p-2'>
@@ -100,13 +100,13 @@ const Wallet = () => {
                   <div className='p-10 border rounded-md border-kernel-dark float-left mb-10 md:mb-0'>
                     <h2 className='font-heading text-3xl text-primary pb-6'>For Everyone</h2>
                     <p>
-                      Anyone may use and extend this <strong>portal</strong>: it is a public gift. We wish to help demonstrate that "wallets" need not compromise your security, limit you to one network at a time, or sell your data to JP Morgan and friends.
+                      Anyone may use and extend this <strong>wallet</strong>: it is a public gift. We wish to help demonstrate that wallets need not compromise your security, or limit you to one network at a time.
                     </p>
                   </div>
                   <div className='p-10 border rounded-md border-kernel-dark float-left mb-10 md:mb-0'>
                     <h2 className='font-heading text-3xl text-primary pb-6'>For Kernel</h2>
                     <p>
-                      If you're a Kernel Fellow, then this portal will take you to many more places. Your keys are used not just to sign transactions, but to grant you access to other Fellows, their adventures, and the various events <strong>unique</strong> to our community.
+                      If you're a Kernel Fellow, then this wallet will take you to even more places. Your keys will grant you access to other Fellows, their adventures, and the various events <strong>unique</strong> to our community.
                     </p>
                   </div>
                 </div>
@@ -116,19 +116,10 @@ const Wallet = () => {
               <h1 className='font-heading text-5xl text-primary pb-6'>A Community of Care</h1>
               <div className='font-secondary'>
                 <p className='pb-10'>
-                  At Kernel, we really care about
-                  <a className='px-2' href='https://www.kernel.community/en/conversation/reciprocity' target='_blank' rel='noreferrer'>
-                    <span className='before:block before:absolute before:-inset-1 before:-skew-y-3 before:bg-kernel-highlight relative inline-block cursor-pointer'>
-                      <span className='relative text-primary'>
-                        <span className='underline decoration-dotted'>
-                          reciprocity.
-                        </span>
-                      </span>
-                    </span>
-                  </a>
+                  At Kernel, we really care about reciprocity.
                 </p>
                 <p>
-                  Here are a few of the founding fun-ders who both make this work possible, and benefit from an open source, non-custodial portal that makes their contracts or technology accessible without relying on their own web interfaces.
+                  Here are a few of the fun-ders who both make this work possible, and benefit from an open source, non-custodial wallet that makes their contracts or technology accessible without relying on their own web interfaces.
                 </p>
                 <div className='columns-1 mb-20 sm:columns-2 md:columns-3 lg:columns-4'>
                   <div className='py-10 float-left sm:pr-2'>


### PR DESCRIPTION
I've done a few things in this PR.

1. I changed the wallet home page so that there are only two options when you first land in it. Either you go and explore everything the wallet has to offer, or you apply to Kernel. I made sure that those who are already existing members see a CTA about "Exploring Kernel" rather than applying.
2. I moved the rest of the functionality - both for the wallet, and for Kernel stuff - into their own pages.
3. I abstracted out the LinkCard component.
4. I rewrote some copy on the wallet index page, to use "wallet" rather than "portal" across the board. I removed the reciprocity link per some feedback from Joan about keeping people focused and not distracting with further links. I changed "log back in" to "sign back in" because that seems more Kernel-y. 
5. I changed a lot of copy in the application flow and process, based on feedback from Boyana's tests. I am now assuming that we will send everyone the wallet link when asking them to apply (though I am trying to account for the fact that they may still find the apply link before the wallet).
6. I wrote a brief "success" message for once people have submitted an application and made sure that it appears once that is the case. We still need to discuss how to display the current status to people in a smooth and intuitive way which keeps their options open.
7. We still need to change the copy for the email that is sent once you have submitted an application.
8. I'm sad that I had to use eslin-disable on one line in Application.jsx and would love to learn how to write that kind of logic in a smoother and cleaner way.